### PR TITLE
[Chore] Add X-A2A-Extensions header logging in server middleware

### DIFF
--- a/samples/python/src/common/server.py
+++ b/samples/python/src/common/server.py
@@ -129,7 +129,11 @@ class _LoggingMiddleware(BaseHTTPMiddleware):
     self._logger.info("%s", request_body)
 
     # If the extension header is present, log a notice.
-    # TODO
+    extension_header = request.headers.get("X-A2A-Extensions")
+    if extension_header:
+      self._logger.info("\n")
+      self._logger.info("[Extension Header]")
+      self._logger.info("X-A2A-Extensions: %s", extension_header)
 
     response = await call_next(request)
 


### PR DESCRIPTION
Implements logging for the X-A2A-Extensions header when present in incoming requests. This improves debugging visibility for A2A protocol extension usage.

Resolves TODO in server.py:132

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/google-agentic-commerce/AP2?tab=contributing-ov-file#how-to-contribute).
- [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [ ] Ensure the tests and linter pass
- [ ] Appropriate docs were updated (if necessary)

Fixes #28 
