### PR TITLE
Add B2B Procurement Agent demo using AP2 (Intent → Cart → Payment with mock OTP)

### DIFF
--- a/samples/python/scenarios/b2b/procurement/README.md
+++ b/samples/python/scenarios/b2b/procurement/README.md
@@ -1,0 +1,20 @@
+# B2B Procurement Agent Demo (AP2)
+
+This sample demonstrates how to apply **Google’s Agent Payment Protocol (AP2)** in a **B2B procurement workflow**.  
+It extends the existing `cards` scenario by adding:
+
+- **Intent Mandate**: created from a natural language request (e.g. “Request a laptop under $1200”).
+- **Cart Mandate**: built from a procurement catalog (`catalog.json`) with vendor + SKU info.
+- **Payment Mandate**: mock card entry + OTP verification (OTP = `123`) to simulate enterprise payment flows.
+
+All mandates are **real AP2 objects** from `src/ap2/types/mandate.py` and `payment_request.py`.  
+They are serialized as JSON into the `mandates/` folder for inspection.
+
+---
+
+## 🚀 Run the Demo
+
+From the repository root:
+
+```bash
+bash samples/python/scenarios/b2b/procurement/run.sh

--- a/samples/python/scenarios/b2b/procurement/README.md
+++ b/samples/python/scenarios/b2b/procurement/README.md
@@ -1,20 +1,19 @@
 # B2B Procurement Agent Demo (AP2)
 
 This sample demonstrates how to apply **Google’s Agent Payment Protocol (AP2)** in a **B2B procurement workflow**.  
-It extends the existing `cards` scenario by adding:
+It extends the existing consumer **cards** demo by simulating enterprise purchasing:
 
 - **Intent Mandate**: created from a natural language request (e.g. “Request a laptop under $1200”).
-- **Cart Mandate**: built from a procurement catalog (`catalog.json`) with vendor + SKU info.
-- **Payment Mandate**: mock card entry + OTP verification (OTP = `123`) to simulate enterprise payment flows.
+- **Cart Mandate**: built from a procurement catalog (`catalog.json`) with vendor and SKU details.
+- **Payment Mandate**: mock card entry + OTP flow (OTP = `123`) to simulate enterprise payment authorization.
 
-All mandates are **real AP2 objects** from `src/ap2/types/mandate.py` and `payment_request.py`.  
-They are serialized as JSON into the `mandates/` folder for inspection.
+All mandates are constructed using the **AP2 Pydantic types** in `src/ap2/types/` and are saved as JSON under the `mandates/` folder.
 
 ---
 
 ## 🚀 Run the Demo
 
-From the repository root:
+From the repo root:
 
 ```bash
 bash samples/python/scenarios/b2b/procurement/run.sh

--- a/samples/python/scenarios/b2b/procurement/catalog.json
+++ b/samples/python/scenarios/b2b/procurement/catalog.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "item-001",
+    "title": "Dell XPS 13 (i7, 16GB RAM)",
+    "category": "laptop",
+    "price": 1150,
+    "vendor": "TechVendor Ltd."
+  },
+  {
+    "id": "item-002",
+    "title": "Office Chair - Ergonomic Mesh",
+    "category": "furniture",
+    "price": 329,
+    "vendor": "FurnishCorp"
+  },
+  {
+    "id": "item-003",
+    "title": "Slack Enterprise License (per user / yr)",
+    "category": "software",
+    "price": 180,
+    "vendor": "Slack Reseller"
+  }
+]

--- a/samples/python/scenarios/b2b/procurement/main.py
+++ b/samples/python/scenarios/b2b/procurement/main.py
@@ -1,0 +1,246 @@
+# main.py
+import json
+import uuid
+import secrets
+from pathlib import Path
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Dict
+
+from fastapi import FastAPI, HTTPException
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+
+# AP2 types (from your repo)
+from ap2.types.mandate import (
+    IntentMandate,
+    CartContents,
+    CartMandate,
+    PaymentMandate,
+    PaymentMandateContents,
+)
+from ap2.types.payment_request import (
+    PaymentCurrencyAmount,
+    PaymentItem,
+    PaymentDetailsInit,
+    PaymentMethodData,
+    PaymentRequest,
+    PaymentResponse,
+)
+
+# --- Paths / data dirs ---
+SCENARIO_DIR = Path(__file__).parent
+CATALOG_PATH = SCENARIO_DIR / "catalog.json"
+MANDATES_DIR = SCENARIO_DIR / "mandates"
+STATIC_DIR = SCENARIO_DIR / "static"
+
+MANDATES_DIR.mkdir(parents=True, exist_ok=True)
+STATIC_DIR.mkdir(parents=True, exist_ok=True)
+
+# load catalog
+if not CATALOG_PATH.exists():
+    raise FileNotFoundError(f"Catalog not found at {CATALOG_PATH}")
+with open(CATALOG_PATH, "r", encoding="utf-8") as f:
+    CATALOG = json.load(f)
+
+app = FastAPI(title="B2B Procurement Agent (AP2) - Demo")
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+
+# --- Helper functions ---
+def save_mandate(prefix: str, mand_dict: dict, id_str: str) -> str:
+    fname = f"{prefix}_{id_str}.json"
+    path = MANDATES_DIR / fname
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(mand_dict, fh, indent=2)
+    print(f"[MANDATE] saved {prefix} -> {path}")
+    return str(path)
+
+
+# --- Request models ---
+class IntentIn(BaseModel):
+    user: str
+    query: str
+    require_confirmation: bool = True
+
+
+class CartIn(BaseModel):
+    intent_id: str
+    item_id: str
+
+
+class PaymentRequestIn(BaseModel):
+    cart_id: str
+    method: str = "card"
+    card_number: Optional[str] = None
+    card_holder: Optional[str] = None
+    expiry: Optional[str] = None
+    cvv: Optional[str] = None
+
+
+class PaymentConfirmIn(BaseModel):
+    otp_token: str
+    otp: str
+
+
+# Simple in-memory OTP store (demo-only)
+OTP_STORE: Dict[str, Dict] = {}
+
+
+# --- Endpoints ---
+
+
+@app.post("/intent")
+def create_intent(payload: IntentIn):
+    """Create an AP2 IntentMandate and return candidate catalog items."""
+    # simple budget parse (e.g., "under 1200" or "under $1200")
+    import re
+
+    m = re.search(r"under\s*\$?(\d+)", payload.query.lower())
+    budget = int(m.group(1)) if m else None
+    category = "laptop" if "laptop" in payload.query.lower() else None
+
+    candidates = []
+    for item in CATALOG:
+        if category and category not in item.get("category", ""):
+            continue
+        if budget and item.get("price", 0) > budget:
+            continue
+        candidates.append(item)
+    if not candidates:
+        candidates = CATALOG[:3]
+
+    intent_id = str(uuid.uuid4())
+    intent_mandate = IntentMandate(
+        user_cart_confirmation_required=payload.require_confirmation,
+        natural_language_description=payload.query,
+        merchants=None,
+        skus=None,
+        requires_refundability=False,
+        intent_expiry=(datetime.now(timezone.utc) + timedelta(minutes=30)).isoformat(),
+    )
+    mand = intent_mandate.dict()
+    save_mandate("intent", mand, intent_id)
+    print(f"[MANDATE] intent {intent_id}")
+    return {"intent_id": intent_id, "mandate": mand, "candidates": candidates}
+
+
+@app.post("/cart")
+def create_cart(body: CartIn):
+    """Create an AP2 CartMandate for the selected item."""
+    item = next((i for i in CATALOG if i["id"] == body.item_id), None)
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
+
+    # Build PaymentRequest (W3C-like)
+    amount = PaymentCurrencyAmount(currency="USD", value=item["price"])
+    payment_item = PaymentItem(label=item["title"], amount=amount)
+    payment_details = PaymentDetailsInit(
+        id=str(uuid.uuid4()), display_items=[payment_item], total=payment_item
+    )
+    payment_request = PaymentRequest(
+        method_data=[PaymentMethodData(supported_methods="mock_invoice")],
+        details=payment_details,
+    )
+
+    contents = CartContents(
+        id=str(uuid.uuid4()),
+        user_cart_confirmation_required=True,
+        payment_request=payment_request,
+        cart_expiry=(datetime.now(timezone.utc) + timedelta(minutes=10)).isoformat(),
+        merchant_name=item["vendor"],
+    )
+
+    cart_mandate = CartMandate(contents=contents)
+    mand_dict = cart_mandate.dict()
+    save_mandate("cart", mand_dict, contents.id)
+    print(f"[MANDATE] cart {contents.id}")
+    return {"cart_id": contents.id, "mandate": mand_dict}
+
+
+@app.post("/payment")
+def initiate_payment(body: PaymentRequestIn):
+    """Initiate payment - returns otp_token (demo-only)."""
+    cart_path = MANDATES_DIR / f"cart_{body.cart_id}.json"
+    if not cart_path.exists():
+        raise HTTPException(status_code=404, detail="Cart mandate not found (save cart first)")
+
+    # store minimal info for confirm step
+    otp_token = secrets.token_urlsafe(12)
+    OTP_STORE[otp_token] = {"cart_id": body.cart_id, "method": body.method}
+    print(f"[OTP] generated token={otp_token} for cart={body.cart_id}")
+
+    # In a real system you'd send an OTP via SMS/email; here we simulate OTP = "123"
+    return {
+        "otp_required": True,
+        "otp_token": otp_token,
+        "notice": "Demo OTP is 123 — enter 123 to confirm (demo only).",
+    }
+
+
+@app.post("/payment/confirm")
+def confirm_payment(body: PaymentConfirmIn):
+    """Confirm OTP and create PaymentMandate (demo)."""
+    entry = OTP_STORE.get(body.otp_token)
+    if not entry:
+        raise HTTPException(status_code=400, detail="Invalid or expired otp_token")
+
+    if body.otp != "123":
+        raise HTTPException(status_code=400, detail="Invalid OTP (demo expects 123)")
+
+    cart_id = entry["cart_id"]
+    cart_path = MANDATES_DIR / f"cart_{cart_id}.json"
+    if not cart_path.exists():
+        raise HTTPException(status_code=404, detail="Cart mandate not found")
+
+    cart_json = json.loads(cart_path.read_text(encoding="utf-8"))
+    # get total amount from cart
+    try:
+        total_info = cart_json["contents"]["payment_request"]["details"]["total"]
+        amount_val = float(total_info["amount"]["value"])
+    except Exception:
+        amount_val = 0.0
+
+    # simulate transaction
+    tx = {"transaction_id": str(uuid.uuid4()), "amount": amount_val, "status": "success", "method": entry["method"]}
+
+    response = PaymentResponse(
+        request_id=str(uuid.uuid4()),
+        method_name=entry["method"],
+        details={"transaction_id": tx["transaction_id"], "status": tx["status"]},
+    )
+
+    pmc = PaymentMandateContents(
+        payment_mandate_id=str(uuid.uuid4()),
+        payment_details_id=str(uuid.uuid4()),
+        payment_details_total=PaymentItem(
+            label="Total",
+            amount=PaymentCurrencyAmount(currency="USD", value=amount_val),
+        ),
+        payment_response=response,
+        merchant_agent=cart_json["contents"]["merchant_name"],
+    )
+
+    payment_mandate = PaymentMandate(payment_mandate_contents=pmc)
+    mand_dict = payment_mandate.dict()
+    saved = save_mandate("payment", mand_dict, pmc.payment_mandate_id)
+    print(f"[MANDATE] payment {pmc.payment_mandate_id} for cart {cart_id}")
+
+    # cleanup OTP (demo)
+    del OTP_STORE[body.otp_token]
+
+    return {
+        "status": "Payment approved and order placed (demo)",
+        "transaction": tx,
+        "payment": mand_dict,
+        "saved_file": saved,
+    }
+
+
+# Serve UI root
+@app.get("/")
+def root():
+    index_file = SCENARIO_DIR / "static" / "index.html"
+    if index_file.exists():
+        return FileResponse(index_file)
+    return {"message": "B2B Procurement Agent API. Visit /docs for Swagger UI."}

--- a/samples/python/scenarios/b2b/procurement/run.sh
+++ b/samples/python/scenarios/b2b/procurement/run.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# A script to run the B2B Procurement Agent demo using AP2 mandates.
+
+set -e
+cd "$(dirname "$0")"
+
+# Setup Python virtual environment if not already present
+if [ ! -d ".venv" ]; then
+  echo "Creating virtual environment..."
+  uv venv .venv
+fi
+
+# Activate venv (Scripts for Windows, bin for Linux/Mac)
+source .venv/Scripts/activate || source .venv/bin/activate
+echo "Virtual environment activated."
+
+# Install AP2 project (editable mode) from repo root
+echo "Installing AP2 project in editable mode..."
+uv pip install -e ../../../../..
+
+# Install FastAPI + Uvicorn if not already installed
+uv pip install fastapi uvicorn
+
+# Run the procurement agent service
+echo "Starting B2B Procurement Agent on http://localhost:8010 ..."
+uv run uvicorn samples.python.scenarios.b2b.procurement.main:app --reload --host 0.0.0.0 --port 8010

--- a/samples/python/scenarios/b2b/procurement/static/index.html
+++ b/samples/python/scenarios/b2b/procurement/static/index.html
@@ -1,0 +1,152 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>B2B Procurement Agent Demo</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 900px; margin: 20px auto; }
+    .card { border:1px solid #ddd; padding:12px; border-radius:8px; margin:12px 0; }
+    button { padding:8px 12px; margin-top:8px; }
+    pre { background:#f7f7f7; padding:10px; border-radius:6px; overflow:auto; }
+    .notice { color:#b00; font-size:0.9em; }
+  </style>
+</head>
+<body>
+  <h1>B2B Procurement Agent (AP2)</h1>
+  <div class="card">
+    <label>User: <input id="user" value="Jyotsna"/></label>
+    <br/><br/>
+    <input id="query" style="width:70%" placeholder="E.g. Request a laptop under $1200"/>
+    <button id="intentBtn">Create Intent</button>
+  </div>
+
+  <div id="candidates"></div>
+  <h3>Mandates Log</h3>
+  <div id="log"></div>
+
+<script>
+const logEl = document.getElementById('log');
+function log(obj){
+  const pre = document.createElement('pre');
+  pre.textContent = JSON.stringify(obj, null, 2);
+  logEl.prepend(pre);
+}
+
+document.getElementById('intentBtn').onclick = async () => {
+  const user = document.getElementById('user').value;
+  const query = document.getElementById('query').value;
+  if (!query) return alert('Enter a request');
+  const resp = await fetch('/intent', {
+    method:'POST', headers:{'content-type':'application/json'},
+    body: JSON.stringify({user, query})
+  });
+  if (!resp.ok) {
+    const e = await resp.json().catch(()=>({detail:'error'}));
+    return alert('Error creating intent: ' + (e.detail || JSON.stringify(e)));
+  }
+  const j = await resp.json();
+  log(j.mandate);
+  showCandidates(j.candidates, j.intent_id);
+};
+
+function showCandidates(candidates, intent_id){
+  const container = document.getElementById('candidates');
+  container.innerHTML = '';
+  candidates.forEach(it=>{
+    const el = document.createElement('div');
+    el.className = 'card';
+    el.innerHTML = `<b>${it.title}</b> ($${it.price})<br/>Vendor: ${it.vendor}<br/>
+      <button>Select & Create Cart</button>`;
+    el.querySelector('button').onclick = async ()=>{
+      const resp = await fetch('/cart', {
+        method:'POST', headers:{'content-type':'application/json'},
+        body: JSON.stringify({intent_id, item_id: it.id})
+      });
+      const j = await resp.json();
+      log(j.mandate);
+      showCartForApproval(j.cart_id, j.mandate);
+    };
+    container.appendChild(el);
+  });
+}
+
+function showCartForApproval(cart_id, cart_mandate){
+  const container = document.getElementById('candidates');
+  const el = document.createElement('div');
+  el.className = 'card';
+
+  const details = cart_mandate.contents.payment_request.details;
+  const item = details.display_items[0];
+
+  el.innerHTML = `<h3>Cart Proposal</h3>
+    <b>${item.label}</b> - $${item.amount.value}<br/>
+    Vendor: ${cart_mandate.contents.merchant_name}<br/>
+    <div id="payment-area-${cart_id}">
+      <h4>Payment (demo)</h4>
+      <div class="notice">Demo only — do not use real card data</div>
+      <label>Card number: <input id="cardnum-${cart_id}" placeholder="4242 4242 4242 4242"/></label><br/>
+      <label>Card holder: <input id="cardname-${cart_id}" placeholder="Alice"/></label><br/>
+      <label>Expiry (MM/YY): <input id="expiry-${cart_id}" placeholder="01/30"/></label>
+      <label>CVV: <input id="cvv-${cart_id}" placeholder="123" style="width:80px"/></label><br/>
+      <button id="pay-btn-${cart_id}">Pay (send OTP)</button>
+    </div>
+
+    <div id="otp-area-${cart_id}" style="display:none;">
+      <label>Enter OTP (demo OTP is 123): <input id="otp-${cart_id}" /></label>
+      <button id="confirm-otp-${cart_id}">Confirm OTP</button>
+    </div>
+
+    <div id="result-${cart_id}"></div>
+  `;
+
+  container.prepend(el);
+
+  document.getElementById(`pay-btn-${cart_id}`).onclick = async () => {
+    const payload = {
+      cart_id,
+      method: "card",
+      card_number: document.getElementById(`cardnum-${cart_id}`).value,
+      card_holder: document.getElementById(`cardname-${cart_id}`).value,
+      expiry: document.getElementById(`expiry-${cart_id}`).value,
+      cvv: document.getElementById(`cvv-${cart_id}`).value
+    };
+    const resp = await fetch('/payment', {
+      method: 'POST',
+      headers: {'content-type':'application/json'},
+      body: JSON.stringify(payload)
+    });
+    if (!resp.ok) {
+      const e = await resp.json().catch(()=>({detail:'error'}));
+      return alert('Payment init failed: ' + (e.detail || JSON.stringify(e)));
+    }
+    const j = await resp.json();
+    document.getElementById(`payment-area-${cart_id}`).style.display = 'none';
+    document.getElementById(`otp-area-${cart_id}`).style.display = 'block';
+    el.dataset.otpToken = j.otp_token;
+    const info = document.getElementById(`result-${cart_id}`);
+    info.textContent = j.notice || "OTP sent (demo)";
+  };
+
+  document.getElementById(`confirm-otp-${cart_id}`).onclick = async () => {
+    const otpToken = el.dataset.otpToken;
+    const otpVal = document.getElementById(`otp-${cart_id}`).value;
+    const resp = await fetch('/payment/confirm', {
+      method:'POST',
+      headers:{'content-type':'application/json'},
+      body: JSON.stringify({otp_token: otpToken, otp: otpVal})
+    });
+    if (!resp.ok) {
+      const err = await resp.json().catch(()=>({detail:"Unknown error"}));
+      alert("Payment failed: " + (err.detail || JSON.stringify(err)));
+      return;
+    }
+    const j = await resp.json();
+    log(j.payment);
+    const info = document.getElementById(`result-${cart_id}`);
+    info.innerHTML = `<b>${j.status}</b><br/>Transaction: ${j.transaction.transaction_id}<br/>Saved: ${j.saved_file}`;
+    document.getElementById(`otp-area-${cart_id}`).style.display = 'none';
+  };
+}
+</script>
+</body>
+</html>

--- a/samples/python/scenarios/b2b/procurement/static/index.html
+++ b/samples/python/scenarios/b2b/procurement/static/index.html
@@ -14,7 +14,7 @@
 <body>
   <h1>B2B Procurement Agent (AP2)</h1>
   <div class="card">
-    <label>User: <input id="user" value="Jyotsna"/></label>
+    <label>User: <input id="user" value="alice"/></label>
     <br/><br/>
     <input id="query" style="width:70%" placeholder="E.g. Request a laptop under $1200"/>
     <button id="intentBtn">Create Intent</button>
@@ -37,13 +37,9 @@ document.getElementById('intentBtn').onclick = async () => {
   const query = document.getElementById('query').value;
   if (!query) return alert('Enter a request');
   const resp = await fetch('/intent', {
-    method:'POST', headers:{'content-type':'application/json'},
+    method:'POST', headers:{'Content-Type':'application/json'},
     body: JSON.stringify({user, query})
   });
-  if (!resp.ok) {
-    const e = await resp.json().catch(()=>({detail:'error'}));
-    return alert('Error creating intent: ' + (e.detail || JSON.stringify(e)));
-  }
   const j = await resp.json();
   log(j.mandate);
   showCandidates(j.candidates, j.intent_id);
@@ -55,17 +51,29 @@ function showCandidates(candidates, intent_id){
   candidates.forEach(it=>{
     const el = document.createElement('div');
     el.className = 'card';
-    el.innerHTML = `<b>${it.title}</b> ($${it.price})<br/>Vendor: ${it.vendor}<br/>
-      <button>Select & Create Cart</button>`;
-    el.querySelector('button').onclick = async ()=>{
+
+    const title = document.createElement('b');
+    title.textContent = `${it.title} ($${it.price})`;
+    const vendor = document.createElement('div');
+    vendor.textContent = `Vendor: ${it.vendor}`;
+
+    const btn = document.createElement('button');
+    btn.textContent = "Select & Create Cart";
+    btn.onclick = async ()=>{
       const resp = await fetch('/cart', {
-        method:'POST', headers:{'content-type':'application/json'},
+        method:'POST', headers:{'Content-Type':'application/json'},
         body: JSON.stringify({intent_id, item_id: it.id})
       });
       const j = await resp.json();
       log(j.mandate);
       showCartForApproval(j.cart_id, j.mandate);
     };
+
+    el.appendChild(title);
+    el.appendChild(document.createElement('br'));
+    el.appendChild(vendor);
+    el.appendChild(document.createElement('br'));
+    el.appendChild(btn);
     container.appendChild(el);
   });
 }
@@ -78,26 +86,44 @@ function showCartForApproval(cart_id, cart_mandate){
   const details = cart_mandate.contents.payment_request.details;
   const item = details.display_items[0];
 
-  el.innerHTML = `<h3>Cart Proposal</h3>
-    <b>${item.label}</b> - $${item.amount.value}<br/>
-    Vendor: ${cart_mandate.contents.merchant_name}<br/>
-    <div id="payment-area-${cart_id}">
-      <h4>Payment (demo)</h4>
-      <div class="notice">Demo only — do not use real card data</div>
-      <label>Card number: <input id="cardnum-${cart_id}" placeholder="4242 4242 4242 4242"/></label><br/>
-      <label>Card holder: <input id="cardname-${cart_id}" placeholder="Alice"/></label><br/>
-      <label>Expiry (MM/YY): <input id="expiry-${cart_id}" placeholder="01/30"/></label>
-      <label>CVV: <input id="cvv-${cart_id}" placeholder="123" style="width:80px"/></label><br/>
-      <button id="pay-btn-${cart_id}">Pay (send OTP)</button>
-    </div>
+  const header = document.createElement('h3');
+  header.textContent = "Cart Proposal";
 
-    <div id="otp-area-${cart_id}" style="display:none;">
-      <label>Enter OTP (demo OTP is 123): <input id="otp-${cart_id}" /></label>
-      <button id="confirm-otp-${cart_id}">Confirm OTP</button>
-    </div>
+  const itemInfo = document.createElement('div');
+  itemInfo.textContent = `${item.label} - $${item.amount.value}`;
 
-    <div id="result-${cart_id}"></div>
+  const vendor = document.createElement('div');
+  vendor.textContent = `Vendor: ${cart_mandate.contents.merchant_name}`;
+
+  const paymentArea = document.createElement('div');
+  paymentArea.id = `payment-area-${cart_id}`;
+  paymentArea.innerHTML = `
+    <h4>Payment (demo)</h4>
+    <div class="notice">Demo only — do not use real card data</div>
+    <label>Card number: <input id="cardnum-${cart_id}" placeholder="4242 4242 4242 4242"/></label><br/>
+    <label>Card holder: <input id="cardname-${cart_id}" placeholder="Alice"/></label><br/>
+    <label>Expiry (MM/YY): <input id="expiry-${cart_id}" placeholder="01/30"/></label>
+    <label>CVV: <input id="cvv-${cart_id}" placeholder="123" style="width:80px"/></label><br/>
+    <button id="pay-btn-${cart_id}">Pay (send OTP)</button>
   `;
+
+  const otpArea = document.createElement('div');
+  otpArea.id = `otp-area-${cart_id}`;
+  otpArea.style.display = 'none';
+  otpArea.innerHTML = `
+    <label>Enter OTP (demo OTP is 123): <input id="otp-${cart_id}" /></label>
+    <button id="confirm-otp-${cart_id}">Confirm OTP</button>
+  `;
+
+  const result = document.createElement('div');
+  result.id = `result-${cart_id}`;
+
+  el.appendChild(header);
+  el.appendChild(itemInfo);
+  el.appendChild(vendor);
+  el.appendChild(paymentArea);
+  el.appendChild(otpArea);
+  el.appendChild(result);
 
   container.prepend(el);
 
@@ -111,39 +137,26 @@ function showCartForApproval(cart_id, cart_mandate){
       cvv: document.getElementById(`cvv-${cart_id}`).value
     };
     const resp = await fetch('/payment', {
-      method: 'POST',
-      headers: {'content-type':'application/json'},
+      method:'POST', headers:{'Content-Type':'application/json'},
       body: JSON.stringify(payload)
     });
-    if (!resp.ok) {
-      const e = await resp.json().catch(()=>({detail:'error'}));
-      return alert('Payment init failed: ' + (e.detail || JSON.stringify(e)));
-    }
     const j = await resp.json();
     document.getElementById(`payment-area-${cart_id}`).style.display = 'none';
     document.getElementById(`otp-area-${cart_id}`).style.display = 'block';
     el.dataset.otpToken = j.otp_token;
-    const info = document.getElementById(`result-${cart_id}`);
-    info.textContent = j.notice || "OTP sent (demo)";
+    result.textContent = j.notice || "OTP sent (demo)";
   };
 
   document.getElementById(`confirm-otp-${cart_id}`).onclick = async () => {
     const otpToken = el.dataset.otpToken;
     const otpVal = document.getElementById(`otp-${cart_id}`).value;
     const resp = await fetch('/payment/confirm', {
-      method:'POST',
-      headers:{'content-type':'application/json'},
+      method:'POST', headers:{'Content-Type':'application/json'},
       body: JSON.stringify({otp_token: otpToken, otp: otpVal})
     });
-    if (!resp.ok) {
-      const err = await resp.json().catch(()=>({detail:"Unknown error"}));
-      alert("Payment failed: " + (err.detail || JSON.stringify(err)));
-      return;
-    }
     const j = await resp.json();
     log(j.payment);
-    const info = document.getElementById(`result-${cart_id}`);
-    info.innerHTML = `<b>${j.status}</b><br/>Transaction: ${j.transaction.transaction_id}<br/>Saved: ${j.saved_file}`;
+    result.textContent = `${j.status} | Transaction: ${j.transaction.transaction_id}`;
     document.getElementById(`otp-area-${cart_id}`).style.display = 'none';
   };
 }


### PR DESCRIPTION
# B2B Procurement Agent Demo (AP2)

This sample demonstrates how to use **Google’s Agent Payment Protocol (AP2)** in a **B2B procurement workflow**.  
It extends the existing `cards` demo by simulating enterprise purchasing:

- **Intent Mandate**: created from a natural language request (e.g. “Request a laptop under $1200”).
- **Cart Mandate**: built from a procurement catalog (`catalog.json`) with vendor and SKU details.
- **Payment Mandate**: mock card entry + OTP flow (OTP = `123`) to simulate enterprise payment authorization.

All mandates are constructed using the **AP2 Pydantic types** in `src/ap2/types/` and are saved as JSON under the `mandates/` folder.

---

## 🚀 Run the Demo

From the repo root:

```bash
bash samples/python/scenarios/b2b/procurement/run.sh
