### PR TITLE
docs: Add prerequisite note for installing `uv` before running scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,28 +46,6 @@ shopping assistant have their source code in [**`samples/android`**](samples/and
 
 - Python 3.10 or higher
 - [`uv`](https://docs.astral.sh/uv/getting-started/installation/) package manager
-### Install [uv](https://docs.astral.sh/uv/getting-started/installation/) (if not installed on your machine)
-
-The AP2 Python scenarios use "uv" for dependency management (instead of pip/venv). Please install it once before running any scenario:
-
-- For installing on macOS / Linux
-
-	```sh
-  curl -LsSf https://astral.sh/uv/install.sh | sh
-  ```
-
-- For Windows machine (PowerShell)
-
-  ```sh
-  powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
-  ```
-
-- You can also verify your version with the below command:
-
-    ```sh
-    uv --version
-    ```
-
 ### Setup
 
 You can authenticate using either a Google API Key or Vertex AI.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,28 @@ shopping assistant have their source code in [**`samples/android`**](samples/and
 
 - Python 3.10 or higher
 
+### Install [uv](https://docs.astral.sh/uv/getting-started/installation/) (if not installed on your machine)
+
+The AP2 Python scenarios uses "uv" for dependency management (instead of pip/venv). Please install it once before running any scenario:
+
+- For installing on macOS / Linux
+
+	```sh
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  ```
+
+- For Windows machine (PowerShell)
+
+  ```sh
+  powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+  ```
+
+- You can also verify your version with the below command:
+
+    ```sh
+    uv --version
+    ```
+
 ### Setup
 
 You can authenticate using either a Google API Key or Vertex AI.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ shopping assistant have their source code in [**`samples/android`**](samples/and
 ### Prerequisites
 
 - Python 3.10 or higher
-
+- [`uv`](https://docs.astral.sh/uv/getting-started/installation/) package manager
 ### Install [uv](https://docs.astral.sh/uv/getting-started/installation/) (if not installed on your machine)
 
 The AP2 Python scenarios use "uv" for dependency management (instead of pip/venv). Please install it once before running any scenario:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ shopping assistant have their source code in [**`samples/android`**](samples/and
 
 - Python 3.10 or higher
 - [`uv`](https://docs.astral.sh/uv/getting-started/installation/) package manager
+
 ### Setup
 
 You can authenticate using either a Google API Key or Vertex AI.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ shopping assistant have their source code in [**`samples/android`**](samples/and
 
 ### Install [uv](https://docs.astral.sh/uv/getting-started/installation/) (if not installed on your machine)
 
-The AP2 Python scenarios uses "uv" for dependency management (instead of pip/venv). Please install it once before running any scenario:
+The AP2 Python scenarios use "uv" for dependency management (instead of pip/venv). Please install it once before running any scenario:
 
 - For installing on macOS / Linux
 


### PR DESCRIPTION

### Summary
Adds a short "Install uv" section to the README pre-requisites section so newcomers don’t hit `uv: command not found`, for a better developer experience. 

### Why
Scenario run scripts depend on uv but the README doesn’t mention it yet. This update avoids onboarding friction.
