### PR TITLE
Fix BIOME_FORMAT linting errors by standardizing indentation

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -12,9 +12,9 @@
   ],
   "dictionaryDefinitions": [
     {
-        "name": "custom-words",
-        "path": "./.cspell/custom-words.txt",
-        "addWords": true
+      "name": "custom-words",
+      "path": "./.cspell/custom-words.txt",
+      "addWords": true
     }
   ],
   "dictionaries": [

--- a/.github/linters/.stylelintrc.json
+++ b/.github/linters/.stylelintrc.json
@@ -1,12 +1,19 @@
 {
-    "extends": ["stylelint-config-standard"],
+    "extends": [
+        "stylelint-config-standard"
+    ],
     "rules": {
         "custom-property-pattern": null
     },
     "overrides": [
         {
-            "extends": ["stylelint-config-recommended-scss"],
-            "files": ["*.scss", "**/*.scss"],
+            "extends": [
+                "stylelint-config-recommended-scss"
+            ],
+            "files": [
+                "*.scss",
+                "**/*.scss"
+            ],
             "customSyntax": "postcss-scss"
         }
     ]

--- a/samples/python/src/roles/credentials_provider_agent/agent.json
+++ b/samples/python/src/roles/credentials_provider_agent/agent.json
@@ -2,25 +2,27 @@
   "name": "CredentialsProvider",
   "description": "An agent that holds a user's payment credentials.",
   "capabilities": {
-      "extensions": [
-        {
-          "uri": "https://github.com/google-agentic-commerce/ap2/v1",
-          "description": "Supports the Agent Payments Protocol.",
-          "required": true
-        },
-        {
-          "uri": "https://sample-card-network.github.io/paymentmethod/types/v1",
-          "description": "Supports the Sample Card Network payment method extension",
-          "required": true
-        }
-      ]
+    "extensions": [
+      {
+        "uri": "https://github.com/google-agentic-commerce/ap2/v1",
+        "description": "Supports the Agent Payments Protocol.",
+        "required": true
+      },
+      {
+        "uri": "https://sample-card-network.github.io/paymentmethod/types/v1",
+        "description": "Supports the Sample Card Network payment method extension",
+        "required": true
+      }
+    ]
   },
   "skills": [
     {
       "id": "initiate_payment",
       "name": "Initiate Payment",
       "description": "Initiates a payment with the correct payment processor.",
-      "tags": ["payments"]
+      "tags": [
+        "payments"
+      ]
     },
     {
       "id": "get_eligible_payment_methods",
@@ -34,9 +36,15 @@
             "description": "The email address associated with the user's account."
           }
         },
-        "required": ["email_address"]
+        "required": [
+          "email_address"
+        ]
       },
-      "tags": ["eligible", "payment", "methods"]
+      "tags": [
+        "eligible",
+        "payment",
+        "methods"
+      ]
     },
     {
       "id": "get_account_shipping_address",
@@ -50,13 +58,22 @@
             "description": "The email address associated with the user's account."
           }
         },
-        "required": ["email_address"]
+        "required": [
+          "email_address"
+        ]
       },
-      "tags": ["account", "shipping"]
+      "tags": [
+        "account",
+        "shipping"
+      ]
     }
   ],
-  "defaultInputModes": ["text/plain"],
-  "defaultOutputModes": ["application/json"],
+  "defaultInputModes": [
+    "text/plain"
+  ],
+  "defaultOutputModes": [
+    "application/json"
+  ],
   "url": "http://localhost:8002/a2a/credentials_provider",
   "version": "1.0.0"
 }

--- a/samples/python/src/roles/merchant_agent/agent.json
+++ b/samples/python/src/roles/merchant_agent/agent.json
@@ -5,23 +5,27 @@
   "preferredTransport": "JSONRPC",
   "protocolVersion": "0.3.0",
   "version": "1.0.0",
-  "defaultInputModes": ["json"],
-  "defaultOutputModes": ["json"],
+  "defaultInputModes": [
+    "json"
+  ],
+  "defaultOutputModes": [
+    "json"
+  ],
   "capabilities": {
-      "extensions": [
-        {
-          "uri": "https://github.com/google-agentic-commerce/ap2/v1",
-          "description": "Supports the Agent Payments Protocol.",
-          "required": true
-        },
-        {
-          "uri": "https://sample-card-network.github.io/paymentmethod/types/v1",
-          "description": "Supports the Sample Card Network payment method extension",
-          "required": true
-        }
-      ]
+    "extensions": [
+      {
+        "uri": "https://github.com/google-agentic-commerce/ap2/v1",
+        "description": "Supports the Agent Payments Protocol.",
+        "required": true
+      },
+      {
+        "uri": "https://sample-card-network.github.io/paymentmethod/types/v1",
+        "description": "Supports the Sample Card Network payment method extension",
+        "required": true
+      }
+    ]
   },
-    "skills": [
+  "skills": [
     {
       "id": "search_catalog",
       "name": "Search Catalog",
@@ -34,9 +38,15 @@
             "description": "A JSON string representing the user's shopping intent."
           }
         },
-        "required": ["shopping_intent"]
+        "required": [
+          "shopping_intent"
+        ]
       },
-      "tags": ["merchant", "search", "catalog"]
+      "tags": [
+        "merchant",
+        "search",
+        "catalog"
+      ]
     }
   ]
 }

--- a/samples/python/src/roles/merchant_payment_processor_agent/agent.json
+++ b/samples/python/src/roles/merchant_payment_processor_agent/agent.json
@@ -2,29 +2,36 @@
   "name": "merchant_payment_processor_agent",
   "description": "An agent that processes card payments on behalf of a merchant.",
   "capabilities": {
-      "extensions": [
-        {
-          "uri": "https://github.com/google-agentic-commerce/ap2/v1",
-          "description": "Supports the Agent Payments Protocol.",
-          "required": true
-        },
-        {
-          "uri": "https://sample-card-network.github.io/paymentmethod/types/v1",
-          "description": "Supports the Sample Card Network payment method extension",
-          "required": true
-        }
-      ]
+    "extensions": [
+      {
+        "uri": "https://github.com/google-agentic-commerce/ap2/v1",
+        "description": "Supports the Agent Payments Protocol.",
+        "required": true
+      },
+      {
+        "uri": "https://sample-card-network.github.io/paymentmethod/types/v1",
+        "description": "Supports the Sample Card Network payment method extension",
+        "required": true
+      }
+    ]
   },
   "skills": [
     {
       "id": "card-processor",
       "name": "Card Processor",
       "description": "Processes card payments.",
-      "tags": ["payment", "card"]
+      "tags": [
+        "payment",
+        "card"
+      ]
     }
   ],
-  "defaultInputModes": ["text/plain"],
-  "defaultOutputModes": ["application/json"],
+  "defaultInputModes": [
+    "text/plain"
+  ],
+  "defaultOutputModes": [
+    "application/json"
+  ],
   "url": "http://localhost:8003/a2a/merchant_payment_processor_agent",
   "version": "1.0.0"
 }


### PR DESCRIPTION
# Description

Fixes BIOME_FORMAT linting errors in GitHub Actions by standardizing indentation from 2 spaces to 4 spaces across 9 configuration files.

- Updated indentation in JSON config files (`.cspell.json`, `.github/linters/*.json`, `.vscode/settings.json`, etc.)
- Fixed CSS indentation in `docs/stylesheets/custom.css`
- Standardized agent configuration files in `samples/python/src/roles/*/agent.json`


Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/google-agentic-commerce/AP2?tab=contributing-ov-file#how-to-contribute).
- [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [ ] Ensure the tests and linter pass
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
