### PR TITLE
chore(lint): Disable Biome format

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -24,6 +24,7 @@ jobs:
           SHELLCHECK_OPTS: -e SC1091 -e 2086
           VALIDATE_ALL_CODEBASE: false
           FILTER_REGEX_EXCLUDE: "^(\\.github/|\\.vscode/|samples/).*|CODE_OF_CONDUCT.md|CHANGELOG.md"
+          VALIDATE_BIOME_FORMAT: false
           VALIDATE_PYTHON_BLACK: false
           VALIDATE_PYTHON_FLAKE8: false
           VALIDATE_PYTHON_ISORT: false


### PR DESCRIPTION
It does not respect VALIDATE_ALL_CODEBASE nor FILTER_REGEX_EXCLUDE so disabling for now.

Question: https://github.com/google-agentic-commerce/AP2/pull/54#issuecomment-3382336555

Will prevent these lint errors: https://github.com/google-agentic-commerce/AP2/actions/runs/18351333407/job/52271829007?pr=54
