### PR TITLE
ci(lint): Disable Shell format

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -40,3 +40,4 @@ jobs:
           VALIDATE_GIT_COMMITLINT: false
           VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
           VALIDATE_JSCPD: false
+          VALIDATE_SHELL_SHFMT: false


### PR DESCRIPTION
The default behavior of SHFMT is not to indent cases in a case statement. We would like these to be indented.

Since we are not able to override this behavior by passing the `-ci` flag to shfmt via super-linter we are disabling it.

https://github.com/mvdan/sh/blob/master/cmd/shfmt/shfmt.1.scd#printer-flags

https://github.com/super-linter/super-linter