### PR TITLE
fix: Serialize Pydantic models before storing in session state

### DIFF
--- a/samples/python/src/roles/shopping_agent/subagents/payment_method_collector/tools.py
+++ b/samples/python/src/roles/shopping_agent/subagents/payment_method_collector/tools.py
@@ -20,6 +20,7 @@ shopping and purchasing process.
 
 from google.adk.tools.tool_context import ToolContext
 
+from ap2.types.mandate import CartMandate
 from ap2.types.payment_request import PAYMENT_METHOD_DATA_DATA_KEY
 from common.a2a_message_builder import A2aMessageBuilder
 from common import artifact_utils
@@ -41,7 +42,7 @@ async def get_payment_methods(
   Returns:
     A dictionary of the user's applicable payment methods.
   """
-  cart_mandate = tool_context.state["cart_mandate"]
+  cart_mandate = CartMandate.model_validate(tool_context.state["cart_mandate"])
   message_builder = (
       A2aMessageBuilder()
       .set_context_id(tool_context.state["shopping_context_id"])

--- a/samples/python/src/roles/shopping_agent/subagents/shopper/tools.py
+++ b/samples/python/src/roles/shopping_agent/subagents/shopper/tools.py
@@ -65,7 +65,7 @@ def create_intent_mandate(
           datetime.now(timezone.utc) + timedelta(days=1)
       ).isoformat(),
   )
-  tool_context.state["intent_mandate"] = intent_mandate
+  tool_context.state["intent_mandate"] = intent_mandate.model_dump()
   return intent_mandate
 
 
@@ -93,7 +93,7 @@ async def find_products(
   message = (
       A2aMessageBuilder()
       .add_text("Find products that match the user's IntentMandate.")
-      .add_data(INTENT_MANDATE_DATA_KEY, intent_mandate.model_dump())
+      .add_data(INTENT_MANDATE_DATA_KEY, intent_mandate)
       .add_data("risk_data", risk_data)
       .add_data("debug_mode", debug_mode)
       .add_data("shopping_agent_id", "trusted_shopping_agent")
@@ -106,7 +106,7 @@ async def find_products(
 
   tool_context.state["shopping_context_id"] = task.context_id
   cart_mandates = _parse_cart_mandates(task.artifacts)
-  tool_context.state["cart_mandates"] = cart_mandates
+  tool_context.state["cart_mandates"] = [cm.model_dump() for cm in cart_mandates]
   return cart_mandates
 
 
@@ -117,7 +117,10 @@ def update_chosen_cart_mandate(cart_id: str, tool_context: ToolContext) -> str:
     cart_id: The ID of the chosen cart.
     tool_context: The ADK supplied tool context.
   """
-  cart_mandates: list[CartMandate] = tool_context.state.get("cart_mandates", [])
+  cart_mandates = [
+      CartMandate.model_validate(cm)
+      for cm in tool_context.state.get("cart_mandates", [])
+  ]
   for cart in cart_mandates:
     print(
         f"Checking cart with ID: {cart.contents.id} with chosen ID: {cart_id}"

--- a/samples/python/src/roles/shopping_agent/subagents/shopper/tools.py
+++ b/samples/python/src/roles/shopping_agent/subagents/shopper/tools.py
@@ -84,16 +84,17 @@ async def find_products(
   Raises:
     RuntimeError: If the merchant agent fails to provide products.
   """
-  intent_mandate = tool_context.state["intent_mandate"]
-  if not intent_mandate:
+  intent_mandate_data = tool_context.state["intent_mandate"]
+  if not intent_mandate_data:
     raise RuntimeError("No IntentMandate found in tool context state.")
+  intent_mandate = IntentMandate.model_validate(intent_mandate_data)
   risk_data = _collect_risk_data(tool_context)
   if not risk_data:
     raise RuntimeError("No risk data found in tool context state.")
   message = (
       A2aMessageBuilder()
       .add_text("Find products that match the user's IntentMandate.")
-      .add_data(INTENT_MANDATE_DATA_KEY, intent_mandate)
+      .add_data(INTENT_MANDATE_DATA_KEY, intent_mandate.model_dump())
       .add_data("risk_data", risk_data)
       .add_data("debug_mode", debug_mode)
       .add_data("shopping_agent_id", "trusted_shopping_agent")


### PR DESCRIPTION
## Summary

- Calls `.model_dump()` on all Pydantic `BaseModel` instances before storing them in `tool_context.state`, ensuring values are plain dicts that `json.dumps()` can serialize.
- Calls `.model_validate()` to reconstruct typed models when reading back from state where attribute access is needed.
- Adds missing `CartMandate` import to `payment_method_collector/tools.py`.

Closes #129

## Affected files

- `samples/python/src/roles/shopping_agent/tools.py` — 5 writes serialized, 3 reads reconstructed
- `samples/python/src/roles/shopping_agent/subagents/shopper/tools.py` — 2 writes serialized, 2 reads reconstructed
- `samples/python/src/roles/shopping_agent/subagents/payment_method_collector/tools.py` — 1 read reconstructed, 1 import added

## Test plan

- [ ] Run `samples/python/scenarios/a2a/human-present/cards/run.sh` and complete a full purchase flow
- [ ] Confirm no `TypeError` on state serialization with `sqlite_session_service`
- [ ] Confirm end-to-end purchase completes (cart selection, payment, receipt)