### PR TITLE
feat: Make LLM model configurable via MODEL env var

### DIFF
--- a/samples/python/src/common/function_call_resolver.py
+++ b/samples/python/src/common/function_call_resolver.py
@@ -19,6 +19,7 @@ use based on the instructions provided.
 """
 
 import logging
+import os
 from typing import Any, Callable
 
 from a2a.server.tasks.task_updater import TaskUpdater
@@ -81,7 +82,7 @@ class FunctionCallResolver:
     """
 
     response = self._client.models.generate_content(
-        model="gemini-2.5-flash",
+        model=os.environ.get("MODEL", "gemini-2.5-flash"),
         contents=prompt,
         config=self._config,
     )

--- a/samples/python/src/common/function_call_resolver.py
+++ b/samples/python/src/common/function_call_resolver.py
@@ -19,13 +19,14 @@ use based on the instructions provided.
 """
 
 import logging
-import os
 from typing import Any, Callable
 
 from a2a.server.tasks.task_updater import TaskUpdater
 from a2a.types import Task
 from google import genai
 from google.genai import types
+
+from common.system_utils import LLM_MODEL
 
 
 DataPartContent = dict[str, Any]
@@ -82,7 +83,7 @@ class FunctionCallResolver:
     """
 
     response = self._client.models.generate_content(
-        model=os.environ.get("MODEL", "gemini-2.5-flash"),
+        model=LLM_MODEL,
         contents=prompt,
         config=self._config,
     )

--- a/samples/python/src/common/retrying_llm_agent.py
+++ b/samples/python/src/common/retrying_llm_agent.py
@@ -39,7 +39,7 @@ class RetryingLlmAgent(LlmAgent):
           author=ctx.agent.name,
           invocation_id=ctx.invocation_id,
           error_message=(
-              "Maximum retries exhausted. The remote Gemini server failed to"
+              "Maximum retries exhausted. The remote LLM server failed to"
               " respond. Please try again later."
           ),
       )
@@ -51,7 +51,7 @@ class RetryingLlmAgent(LlmAgent):
         yield Event(
             author=ctx.agent.name,
             invocation_id=ctx.invocation_id,
-            error_message="Gemini server error. Retrying...",
+            error_message="LLM server error. Retrying...",
             custom_metadata={"error": str(e)},
         )
         async for event in self._retry_async(ctx, retries_left - 1):

--- a/samples/python/src/common/system_utils.py
+++ b/samples/python/src/common/system_utils.py
@@ -14,6 +14,10 @@
 
 """Helper functions related to the system."""
 
+import os
+
+LLM_MODEL = os.environ.get("MODEL", "gemini-2.5-flash")
+
 DEBUG_MODE_INSTRUCTIONS = """
     This is really important! If the agent or user asks you to be verbose or if debug_mode is True, do the following:
       1. If this is the the start of a new task, explain who you are, what you are going to do, what tools you use, and what agents you delegate to.

--- a/samples/python/src/roles/merchant_agent/sub_agents/catalog_agent.py
+++ b/samples/python/src/roles/merchant_agent/sub_agents/catalog_agent.py
@@ -68,7 +68,7 @@ async def find_items_workflow(
         """ % DEBUG_MODE_INSTRUCTIONS
 
   llm_response = llm_client.models.generate_content(
-      model="gemini-2.5-flash",
+      model=os.environ.get("MODEL", "gemini-2.5-flash"),
       contents=prompt,
       config={
           "response_mime_type": "application/json",

--- a/samples/python/src/roles/merchant_agent/sub_agents/catalog_agent.py
+++ b/samples/python/src/roles/merchant_agent/sub_agents/catalog_agent.py
@@ -44,6 +44,7 @@ from ap2.types.payment_request import PaymentOptions
 from ap2.types.payment_request import PaymentRequest
 from common import message_utils
 from common.system_utils import DEBUG_MODE_INSTRUCTIONS
+from common.system_utils import LLM_MODEL
 
 
 async def find_items_workflow(
@@ -68,7 +69,7 @@ async def find_items_workflow(
         """ % DEBUG_MODE_INSTRUCTIONS
 
   llm_response = llm_client.models.generate_content(
-      model=os.environ.get("MODEL", "gemini-2.5-flash"),
+      model=LLM_MODEL,
       contents=prompt,
       config={
           "response_mime_type": "application/json",

--- a/samples/python/src/roles/shopping_agent/agent.py
+++ b/samples/python/src/roles/shopping_agent/agent.py
@@ -22,6 +22,8 @@ The Google ADK powers this shopping agent, chosen for its simplicity and
 efficiency in developing robust LLM agents. 
 """
 
+import os
+
 from . import tools
 from .subagents.payment_method_collector.agent import payment_method_collector
 from .subagents.shipping_address_collector.agent import shipping_address_collector
@@ -32,7 +34,7 @@ from common.system_utils import DEBUG_MODE_INSTRUCTIONS
 
 root_agent = RetryingLlmAgent(
     max_retries=5,
-    model="gemini-2.5-flash",
+    model=os.environ.get("MODEL", "gemini-2.5-flash"),
     name="root_agent",
     instruction="""
           You are a shopping agent responsible for helping users find and

--- a/samples/python/src/roles/shopping_agent/agent.py
+++ b/samples/python/src/roles/shopping_agent/agent.py
@@ -22,19 +22,18 @@ The Google ADK powers this shopping agent, chosen for its simplicity and
 efficiency in developing robust LLM agents. 
 """
 
-import os
-
 from . import tools
 from .subagents.payment_method_collector.agent import payment_method_collector
 from .subagents.shipping_address_collector.agent import shipping_address_collector
 from .subagents.shopper.agent import shopper
 from common.retrying_llm_agent import RetryingLlmAgent
 from common.system_utils import DEBUG_MODE_INSTRUCTIONS
+from common.system_utils import LLM_MODEL
 
 
 root_agent = RetryingLlmAgent(
     max_retries=5,
-    model=os.environ.get("MODEL", "gemini-2.5-flash"),
+    model=LLM_MODEL,
     name="root_agent",
     instruction="""
           You are a shopping agent responsible for helping users find and

--- a/samples/python/src/roles/shopping_agent/subagents/payment_method_collector/agent.py
+++ b/samples/python/src/roles/shopping_agent/subagents/payment_method_collector/agent.py
@@ -25,13 +25,15 @@ After selection, the agent gets a purchase token from the credentials
 provider, which is then sent to the merchant agent for payment.
 """
 
+import os
+
 from . import tools
 from common.retrying_llm_agent import RetryingLlmAgent
 from common.system_utils import DEBUG_MODE_INSTRUCTIONS
 
 
 payment_method_collector = RetryingLlmAgent(
-    model="gemini-2.5-flash",
+    model=os.environ.get("MODEL", "gemini-2.5-flash"),
     name="payment_method_collector",
     max_retries=5,
     instruction="""

--- a/samples/python/src/roles/shopping_agent/subagents/payment_method_collector/agent.py
+++ b/samples/python/src/roles/shopping_agent/subagents/payment_method_collector/agent.py
@@ -25,15 +25,14 @@ After selection, the agent gets a purchase token from the credentials
 provider, which is then sent to the merchant agent for payment.
 """
 
-import os
-
 from . import tools
 from common.retrying_llm_agent import RetryingLlmAgent
 from common.system_utils import DEBUG_MODE_INSTRUCTIONS
+from common.system_utils import LLM_MODEL
 
 
 payment_method_collector = RetryingLlmAgent(
-    model=os.environ.get("MODEL", "gemini-2.5-flash"),
+    model=LLM_MODEL,
     name="payment_method_collector",
     max_retries=5,
     instruction="""

--- a/samples/python/src/roles/shopping_agent/subagents/shipping_address_collector/agent.py
+++ b/samples/python/src/roles/shopping_agent/subagents/shipping_address_collector/agent.py
@@ -26,14 +26,13 @@ digital wallet to provide their shipping address.
 This is just one of many possible approaches.
 """
 
-import os
-
 from . import tools
 from common.retrying_llm_agent import RetryingLlmAgent
 from common.system_utils import DEBUG_MODE_INSTRUCTIONS
+from common.system_utils import LLM_MODEL
 
 shipping_address_collector = RetryingLlmAgent(
-    model=os.environ.get("MODEL", "gemini-2.5-flash"),
+    model=LLM_MODEL,
     name="shipping_address_collector",
     max_retries=5,
     instruction="""

--- a/samples/python/src/roles/shopping_agent/subagents/shipping_address_collector/agent.py
+++ b/samples/python/src/roles/shopping_agent/subagents/shipping_address_collector/agent.py
@@ -26,12 +26,14 @@ digital wallet to provide their shipping address.
 This is just one of many possible approaches.
 """
 
+import os
+
 from . import tools
 from common.retrying_llm_agent import RetryingLlmAgent
 from common.system_utils import DEBUG_MODE_INSTRUCTIONS
 
 shipping_address_collector = RetryingLlmAgent(
-    model="gemini-2.5-flash",
+    model=os.environ.get("MODEL", "gemini-2.5-flash"),
     name="shipping_address_collector",
     max_retries=5,
     instruction="""

--- a/samples/python/src/roles/shopping_agent/subagents/shopper/agent.py
+++ b/samples/python/src/roles/shopping_agent/subagents/shopper/agent.py
@@ -24,13 +24,15 @@ multiple CartMandate objects, assuming the user will select one of the options.
 This is just one of many possible approaches.
 """
 
+import os
+
 from . import tools
 from common.retrying_llm_agent import RetryingLlmAgent
 from common.system_utils import DEBUG_MODE_INSTRUCTIONS
 
 
 shopper = RetryingLlmAgent(
-    model="gemini-2.5-flash",
+    model=os.environ.get("MODEL", "gemini-2.5-flash"),
     name="shopper",
     max_retries=5,
     instruction="""

--- a/samples/python/src/roles/shopping_agent/subagents/shopper/agent.py
+++ b/samples/python/src/roles/shopping_agent/subagents/shopper/agent.py
@@ -24,15 +24,14 @@ multiple CartMandate objects, assuming the user will select one of the options.
 This is just one of many possible approaches.
 """
 
-import os
-
 from . import tools
 from common.retrying_llm_agent import RetryingLlmAgent
 from common.system_utils import DEBUG_MODE_INSTRUCTIONS
+from common.system_utils import LLM_MODEL
 
 
 shopper = RetryingLlmAgent(
-    model=os.environ.get("MODEL", "gemini-2.5-flash"),
+    model=LLM_MODEL,
     name="shopper",
     max_retries=5,
     instruction="""


### PR DESCRIPTION
## Summary

- Replaces all 6 hardcoded `"gemini-2.5-flash"` model strings with `os.environ.get("MODEL", "gemini-2.5-flash")`, allowing users to configure the model without editing source code.
- Generalizes "Gemini" references in error messages to "LLM" for model-agnostic consistency.
- Default behavior is unchanged when `MODEL` is not set.

Closes #75

## Usage

```sh
# Use default (gemini-2.5-flash)
samples/python/scenarios/a2a/human-present/cards/run.sh

# Use a different model
export MODEL="gemini-2.5-pro"
samples/python/scenarios/a2a/human-present/cards/run.sh
```

## Affected files

- `samples/python/src/roles/shopping_agent/agent.py`
- `samples/python/src/roles/shopping_agent/subagents/shopper/agent.py`
- `samples/python/src/roles/shopping_agent/subagents/shipping_address_collector/agent.py`
- `samples/python/src/roles/shopping_agent/subagents/payment_method_collector/agent.py`
- `samples/python/src/roles/merchant_agent/sub_agents/catalog_agent.py`
- `samples/python/src/common/function_call_resolver.py`
- `samples/python/src/common/retrying_llm_agent.py`

## Test plan

- [ ] Run sample with default (no `MODEL` set) — should behave identically to before
- [ ] Run sample with `MODEL=gemini-2.5-pro` — should use the specified model
- [ ] Verify no remaining hardcoded model strings in `samples/python/src/`