### PR TITLE
fix: add missing run.sh for x402 human-present scenario

### DIFF
--- a/samples/python/scenarios/a2a/human-present/x402/README.md
+++ b/samples/python/scenarios/a2a/human-present/x402/README.md
@@ -66,7 +66,7 @@ GOOGLE_API_KEY variable in one of two ways.
 You can execute the following command to run all of the steps in one terminal:
 
 ```sh
-samples/python/scenarios/a2a/human-present/cards/run.sh --payment-method x402
+bash samples/python/scenarios/a2a/human-present/x402/run.sh
 ```
 
 Or you can run each server in its own terminal (ensure `PAYMENT_METHOD=x402` is set for all processes):

--- a/samples/python/scenarios/a2a/human-present/x402/run.sh
+++ b/samples/python/scenarios/a2a/human-present/x402/run.sh
@@ -5,4 +5,4 @@
 # the x402 payment method.
 
 SCRIPT_DIR="$(dirname "$0")"
-exec bash "$SCRIPT_DIR/../cards/run.sh" --payment-method x402
+exec bash "$SCRIPT_DIR/../cards/run.sh" --payment-method x402 "$@"

--- a/samples/python/scenarios/a2a/human-present/x402/run.sh
+++ b/samples/python/scenarios/a2a/human-present/x402/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# A script to automate the execution of the x402 payment example.
+# This is a convenience wrapper that runs the standard scenario with
+# the x402 payment method.
+
+SCRIPT_DIR="$(dirname "$0")"
+exec bash "$SCRIPT_DIR/../cards/run.sh" --payment-method x402


### PR DESCRIPTION
## Summary
- Add a convenience `run.sh` script to `samples/python/scenarios/a2a/human-present/x402/` that delegates to the existing `cards/run.sh` with `--payment-method x402`
- Update the x402 README to reference its own `run.sh` instead of pointing to `cards/run.sh`

Closes #107

## Test plan
- [ ] Verify `bash samples/python/scenarios/a2a/human-present/x402/run.sh` starts the x402 scenario correctly
- [ ] Verify the script delegates to `cards/run.sh` with the correct `--payment-method x402` flag