### PR TITLE
docs: add Andru (H&S) to partners list 

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -7,6 +7,7 @@ agentic
 Agentic
 agenticpayments
 Algorand
+Andru
 androidx
 Applebot
 appname

--- a/docs/partners.md
+++ b/docs/partners.md
@@ -14,6 +14,7 @@ build, codify, and adopt A2A as the standard protocol for AI agent payments.
 - [AliExpress](https://www.aliexpress.com/)
 - [Amadeus](https://www.amadeus.com/)
 - [American Express](https://www.americanexpress.com/)
+- [Andru (H&S)](https://andru.ai/)
 - [Ant Group](https://www.antgroup.com/en/)
 - [Ant International](https://www.antinternational.com/)
 - [Auth0](https://auth0.com/)


### PR DESCRIPTION
- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google-agentic-commerce/AP2?tab=contributing-ov-file#how-to-contribute).
  - [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - [x] Ensure the tests and linter pass
  - [x] Appropriate docs were updated (if necessary)

## Summary

Adds Andru (H&S) to the AP2 partners list in `docs/partners.md`.

Andru is an operational empathy platform for Series A technical SaaS founders. Our A2A agent declares the AP2 extension and supports both prepaid wallet and Stripe metered billing. 19 tools with per-tool pricing ($3–$39/query), 50 free queries/month via zero-field provisioning.

- AgentCard with AP2 extension: https://hs-andru-test.onrender.com/.well-known/agent.json
- Zero-field registration: `POST https://hs-andru-test.onrender.com/api/a2a/register`
- Also updates `.cspell/custom-words.txt` to pass linter