### PR TITLE
fix: add missing run.sh for x402 scenario

### DIFF
--- a/samples/python/scenarios/a2a/human-present/x402/README.md
+++ b/samples/python/scenarios/a2a/human-present/x402/README.md
@@ -66,7 +66,7 @@ GOOGLE_API_KEY variable in one of two ways.
 You can execute the following command to run all of the steps in one terminal:
 
 ```sh
-samples/python/scenarios/a2a/human-present/cards/run.sh --payment-method x402
+samples/python/scenarios/a2a/human-present/x402/run.sh
 ```
 
 Or you can run each server in its own terminal (ensure `PAYMENT_METHOD=x402` is set for all processes):

--- a/samples/python/scenarios/a2a/human-present/x402/run.sh
+++ b/samples/python/scenarios/a2a/human-present/x402/run.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
+set -e
 
 # A script to automate the execution of the x402 payment example.
 # This is a convenience wrapper that runs the standard scenario with
 # the x402 payment method.
 
-SCRIPT_DIR="$(dirname "$0")"
-exec bash "$SCRIPT_DIR/../cards/run.sh" --payment-method x402 "$@"
+# The wrapped script, cards/run.sh, expects to be run from the repository root.
+# To make this script runnable from any directory, we first change to the repo root.
+cd "$(dirname "$0")/../../../../../../"
+
+exec bash "samples/python/scenarios/a2a/human-present/cards/run.sh" --payment-method x402 "$@"

--- a/samples/python/scenarios/a2a/human-present/x402/run.sh
+++ b/samples/python/scenarios/a2a/human-present/x402/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# A script to automate the execution of the x402 payment example.
+# This is a convenience wrapper that runs the standard scenario with
+# the x402 payment method.
+
+SCRIPT_DIR="$(dirname "$0")"
+exec bash "$SCRIPT_DIR/../cards/run.sh" --payment-method x402 "$@"


### PR DESCRIPTION
## Summary
- Add a `run.sh` script to `samples/python/scenarios/a2a/human-present/x402/` that delegates to the existing `cards/run.sh` with `--payment-method x402`
- Update the x402 README to reference its own `run.sh` instead of pointing to `cards/run.sh`

Fixes #107

## Test plan
- [ ] Verify `bash samples/python/scenarios/a2a/human-present/x402/run.sh` starts the x402 scenario correctly
- [ ] Verify the script delegates to `cards/run.sh` with the correct `--payment-method x402` flag
- [ ] Verify additional arguments are passed through via `"$@"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)