### PR TITLE
fix: Change PaymentCurrencyAmount.value type from float to string

### DIFF
--- a/samples/android/shopping_assistant/app/src/main/java/com/example/a2achatassistant/agent/DpcHelper.kt
+++ b/samples/android/shopping_assistant/app/src/main/java/com/example/a2achatassistant/agent/DpcHelper.kt
@@ -43,11 +43,11 @@ fun constructDPCRequest(cartMandate: CartMandate, merchantName: String): String 
   // This nonce should ideally be generated securely for each transaction.
   val nonce = UUID.randomUUID().toString()
 
-  val totalValueString = String.format("%.2f", totalValue)
+  val totalValueString = totalValue
 
   val tableRows =
     cartMandate.contents.paymentRequest.details.displayItems.map { item ->
-      listOf(item.label, "1", item.amount.value.toString(), item.amount.value.toString())
+      listOf(item.label, "1", item.amount.value, item.amount.value)
     }
 
   for (row in tableRows) {

--- a/samples/android/shopping_assistant/app/src/main/java/com/example/a2achatassistant/data/ShoppingAgentTypes.kt
+++ b/samples/android/shopping_assistant/app/src/main/java/com/example/a2achatassistant/data/ShoppingAgentTypes.kt
@@ -108,7 +108,7 @@ data class DisplayItem(
   @SerialName("refund_period") val refundPeriod: Int? = null,
 )
 
-@Serializable data class Amount(val currency: String, val value: Double)
+@Serializable data class Amount(val currency: String, val value: String)
 
 @Serializable
 data class ShippingOption(

--- a/samples/go/pkg/ap2/types/payment_request.go
+++ b/samples/go/pkg/ap2/types/payment_request.go
@@ -18,7 +18,7 @@ const PaymentMethodDataDataKey = "payment_request.PaymentMethodData"
 
 type PaymentCurrencyAmount struct {
 	Currency string  `json:"currency"`
-	Value    float64 `json:"value"`
+	Value    string  `json:"value"`
 }
 
 type PaymentItem struct {

--- a/samples/go/pkg/roles/merchant_agent/storage.go
+++ b/samples/go/pkg/roles/merchant_agent/storage.go
@@ -175,7 +175,7 @@ func (s *Storage) CreateCartMandate(products []Product) *types.CartMandate {
 			Label: product.Name,
 			Amount: types.PaymentCurrencyAmount{
 				Currency: "USD",
-				Value:    strconv.FormatFloat(product.Price, 'f', -1, 64),
+Value:    strconv.FormatFloat(product.Price, 'f', 2, 64),
 			},
 			RefundPeriod: 30,
 		}
@@ -201,7 +201,7 @@ func (s *Storage) CreateCartMandate(products []Product) *types.CartMandate {
 						Label: "Total",
 						Amount: types.PaymentCurrencyAmount{
 							Currency: "USD",
-							Value:    strconv.FormatFloat(total, 'f', -1, 64),
+Value:    strconv.FormatFloat(total, 'f', 2, 64),
 						},
 						RefundPeriod: 30,
 					},

--- a/samples/go/pkg/roles/merchant_agent/storage.go
+++ b/samples/go/pkg/roles/merchant_agent/storage.go
@@ -15,6 +15,7 @@
 package merchant_agent
 
 import (
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -174,7 +175,7 @@ func (s *Storage) CreateCartMandate(products []Product) *types.CartMandate {
 			Label: product.Name,
 			Amount: types.PaymentCurrencyAmount{
 				Currency: "USD",
-				Value:    product.Price,
+				Value:    strconv.FormatFloat(product.Price, 'f', -1, 64),
 			},
 			RefundPeriod: 30,
 		}
@@ -200,7 +201,7 @@ func (s *Storage) CreateCartMandate(products []Product) *types.CartMandate {
 						Label: "Total",
 						Amount: types.PaymentCurrencyAmount{
 							Currency: "USD",
-							Value:    total,
+							Value:    strconv.FormatFloat(total, 'f', -1, 64),
 						},
 						RefundPeriod: 30,
 					},

--- a/samples/go/pkg/roles/merchant_agent/tools.go
+++ b/samples/go/pkg/roles/merchant_agent/tools.go
@@ -166,7 +166,7 @@ func generateProductsWithLLM(query string, updater *common.TaskUpdater, storage 
 			SKU:         fmt.Sprintf("GEN-%d", i+1),
 			Name:        item.Label,
 			Description: fmt.Sprintf("Generated product for: %s", query),
-			Price:       func() float64 { v, _ := strconv.ParseFloat(item.Amount.Value, 64); return v }(),
+Price:       func() float64 { v, err := strconv.ParseFloat(item.Amount.Value, 64); if err != nil { fmt.Fprintf(os.Stderr, "could not parse price '%s': %v\n", item.Amount.Value, err) }; return v }(),
 			Category:    "Generated",
 		}
 
@@ -242,7 +242,7 @@ func UpdateCart(dataParts []map[string]interface{}, updater *common.TaskUpdater)
 		v, _ := strconv.ParseFloat(item.Amount.Value, 64)
 		newTotal += v
 	}
-	cartMandate.Contents.PaymentRequest.Details.Total.Amount.Value = strconv.FormatFloat(newTotal, 'f', -1, 64)
+cartMandate.Contents.PaymentRequest.Details.Total.Amount.Value = strconv.FormatFloat(newTotal, 'f', 2, 64)
 
 	authToken := FakeJWT
 	cartMandate.MerchantAuthorization = &authToken

--- a/samples/go/pkg/roles/merchant_agent/tools.go
+++ b/samples/go/pkg/roles/merchant_agent/tools.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/google-agentic-commerce/ap2/samples/go/pkg/ap2/types"
 	"github.com/google-agentic-commerce/ap2/samples/go/pkg/common"
@@ -81,8 +82,8 @@ func generateProductsWithLLM(query string, updater *common.TaskUpdater, storage 
 
 	// Define the schema for structured output using Go struct tags
 	type Amount struct {
-		Currency string  `json:"currency"`
-		Value    float64 `json:"value"`
+		Currency string `json:"currency"`
+		Value    string `json:"value"`
 	}
 
 	type PaymentItem struct {
@@ -109,7 +110,7 @@ func generateProductsWithLLM(query string, updater *common.TaskUpdater, storage 
 							Enum: []string{"USD"},
 						},
 						"value": {
-							Type:        genai.TypeNumber,
+							Type:        genai.TypeString,
 							Description: "Price in USD",
 						},
 					},
@@ -165,7 +166,7 @@ func generateProductsWithLLM(query string, updater *common.TaskUpdater, storage 
 			SKU:         fmt.Sprintf("GEN-%d", i+1),
 			Name:        item.Label,
 			Description: fmt.Sprintf("Generated product for: %s", query),
-			Price:       item.Amount.Value,
+			Price:       func() float64 { v, _ := strconv.ParseFloat(item.Amount.Value, 64); return v }(),
 			Category:    "Generated",
 		}
 
@@ -221,12 +222,12 @@ func UpdateCart(dataParts []map[string]interface{}, updater *common.TaskUpdater)
 
 	shippingCost := types.PaymentItem{
 		Label:        "Shipping",
-		Amount:       types.PaymentCurrencyAmount{Currency: "USD", Value: 2.00},
+		Amount:       types.PaymentCurrencyAmount{Currency: "USD", Value: "2.00"},
 		RefundPeriod: 30,
 	}
 	taxCost := types.PaymentItem{
 		Label:        "Tax",
-		Amount:       types.PaymentCurrencyAmount{Currency: "USD", Value: 1.50},
+		Amount:       types.PaymentCurrencyAmount{Currency: "USD", Value: "1.50"},
 		RefundPeriod: 30,
 	}
 
@@ -238,9 +239,10 @@ func UpdateCart(dataParts []map[string]interface{}, updater *common.TaskUpdater)
 
 	var newTotal float64
 	for _, item := range cartMandate.Contents.PaymentRequest.Details.DisplayItems {
-		newTotal += item.Amount.Value
+		v, _ := strconv.ParseFloat(item.Amount.Value, 64)
+		newTotal += v
 	}
-	cartMandate.Contents.PaymentRequest.Details.Total.Amount.Value = newTotal
+	cartMandate.Contents.PaymentRequest.Details.Total.Amount.Value = strconv.FormatFloat(newTotal, 'f', -1, 64)
 
 	authToken := FakeJWT
 	cartMandate.MerchantAuthorization = &authToken

--- a/samples/python/src/roles/merchant_agent/sub_agents/catalog_agent.py
+++ b/samples/python/src/roles/merchant_agent/sub_agents/catalog_agent.py
@@ -121,7 +121,7 @@ async def _create_and_add_cart_mandate_artifact(
                     "network": "base",
                     "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bda02913",
                     "payTo": "0xMerchantWalletAddress",
-                    "maxAmountRequired": str(int(item.amount.value * 1000000))
+                    "maxAmountRequired": str(int(float(item.amount.value) * 1000000))
                 }]
             }
         )

--- a/samples/python/src/roles/merchant_agent/tools.py
+++ b/samples/python/src/roles/merchant_agent/tools.py
@@ -105,11 +105,11 @@ async def update_cart(
     tax_and_shipping_costs = [
         PaymentItem(
             label="Shipping",
-            amount=PaymentCurrencyAmount(currency="USD", value=2.00),
+            amount=PaymentCurrencyAmount(currency="USD", value="2.00"),
         ),
         PaymentItem(
             label="Tax",
-            amount=PaymentCurrencyAmount(currency="USD", value=1.50),
+            amount=PaymentCurrencyAmount(currency="USD", value="1.50"),
         ),
     ]
 
@@ -121,9 +121,9 @@ async def update_cart(
       payment_request.details.display_items.extend(tax_and_shipping_costs)
 
     # Recompute the total amount of the PaymentRequest:
-    payment_request.details.total.amount.value = sum(
-        item.amount.value for item in payment_request.details.display_items
-    )
+    payment_request.details.total.amount.value = str(sum(
+        float(item.amount.value) for item in payment_request.details.display_items
+    ))
 
     # A base64url-encoded JSON Web Token (JWT) that digitally signs the cart
     # contents by the merchant's private key.

--- a/src/ap2/types/payment_request.py
+++ b/src/ap2/types/payment_request.py
@@ -41,7 +41,7 @@ class PaymentCurrencyAmount(BaseModel):
   currency: str = Field(
       ..., description="The three-letter ISO 4217 currency code."
   )
-  value: float = Field(..., description="The monetary value.")
+  value: str = Field(..., description="The monetary value.")
 
 
 class PaymentItem(BaseModel):


### PR DESCRIPTION
## Summary

The `value` field in `PaymentCurrencyAmount` is currently defined as a numeric type (`float`/`float64`/`Double`), which is inconsistent with the [W3C Payment Request API spec](https://www.w3.org/TR/payment-request/#dom-paymentcurrencyamount) where `value` is defined as a `DOMString`. This PR aligns the type definition with the W3C standard for cross-language consistency.

### Changes

- Change `PaymentCurrencyAmount.value` from numeric type to string across Python (`float` → `str`), Go (`float64` → `string`), and Kotlin (`Double` → `String`)
- Update all sample code to use string literal values (e.g., `"2.00"` instead of `2.00`) and add `float()` / `strconv.ParseFloat()` conversions where arithmetic operations are needed

## Files changed (8 files)

| File | Change |
|------|--------|
| `src/ap2/types/payment_request.py` | `float` → `str` |
| `samples/go/pkg/ap2/types/payment_request.go` | `float64` → `string` |
| `samples/android/.../data/ShoppingAgentTypes.kt` | `Double` → `String` |
| `samples/python/.../merchant_agent/tools.py` | String literals + `float()` for sum |
| `samples/python/.../sub_agents/catalog_agent.py` | `float()` conversion for arithmetic |
| `samples/go/.../merchant_agent/tools.go` | String literals + `strconv` conversions |
| `samples/go/.../merchant_agent/storage.go` | `strconv.FormatFloat` for Price→Value |
| `samples/android/.../agent/DpcHelper.kt` | Remove redundant `.toString()` calls |

## Test plan

- [ ] Verify Python samples run correctly with string values
- [ ] Verify Go samples compile and run correctly
- [ ] Verify Android sample builds successfully
