### PR TITLE
docs: Update partners.md to include t54

### DIFF
--- a/docs/partners.md
+++ b/docs/partners.md
@@ -105,6 +105,7 @@ build, codify, and adopt A2A as the standard protocol for AI agent payments.
 - [Solana](https://solana.com/)
 - [Splitit](https://www.splitit.com/)
 - [Synchrony Financial](https://www.synchrony.com/)
+- [t54](https://www.t54.ai/)
 - [TenPay](https://global.tenpay.com/)
 - [Tether](https://tether.io/)
 - [Thales](https://www.thalesgroup.com/)


### PR DESCRIPTION
Adding t54 for their work on the Agentic Risk Standard (ARS), https://docs.t54.ai/. ARS introduces an actuarial framework for underwriting AI agent transactions and managing risk. Their theoretical mechanisms—such as "structured agreements" and escrow-based settlement— plan to map to AP2's Verifiable Digital Credentials (Mandates), providing a highly complementary, implementable risk and liability layer explicitly on top of the AP2/A2A stack.
