### PR TITLE
docs: add stablecoin payments topic

### DIFF
--- a/docs/topics/ap2-and-stablecoin-payments.md
+++ b/docs/topics/ap2-and-stablecoin-payments.md
@@ -1,0 +1,50 @@
+# Exploring Stablecoin Payments in AP2
+This document is an exploratory contribution examining how the Agent Payments
+Protocol (AP2) could apply to stablecoin-based payments. It does not represent
+an official AP2 specification.
+## Push vs Pull Payment Semantics
+AP2 v0.1 focuses on "pull" payment methods (e.g., credit/debit cards), where
+the merchant initiates a charge against the user's credentials. Stablecoin
+payments operate on "push" semantics — the payer initiates a transfer directly
+to the payee's address.
+Despite this difference, AP2's core mandate architecture could be applicable
+to push payments as well. The following table outlines a conceptual mapping
+of how each AP2 component might function in a stablecoin context:
+| AP2 Component | Pull Payments (Cards) | Push Payments (Stablecoins) |
+|---------------|----------------------|---------------------------|
+| Cart Mandate | Merchant signs cart, user confirms | Same — cart signing is payment-agnostic |
+| Payment Mandate | Shared with card network/issuer | Could be shared with settlement network for trust |
+| Credentials Provider | Returns card token | Could execute transfer and return proof of payment |
+| MPP | Initiates charge | A verification layer could confirm on-chain receipt |
+## Potential Use Cases
+### Social Entertainment Payments
+Social platforms process high volumes of micro-transactions across borders.
+Possible AP2 applications include:
+- **Creator Tipping (Human Present):** A user tips a live streamer in USDT.
+  The Shopping Agent facilitates the flow, the Merchant Agent builds a cart
+  for the tip amount, and the user confirms via a Cart Mandate. Settlement
+  could occur on-chain.
+- **Digital Gifting (Human Present):** A user purchases virtual gifts to send
+  to a friend. The cart contains multiple virtual items with a total settled
+  in stablecoins.
+- **Subscriptions (Human Not Present — Future):** A user subscribes to premium
+  content with monthly stablecoin payments. This would align with future AP2
+  capabilities such as Intent Mandates planned for v1.x.
+### Cross-Border B2B Settlement
+Stablecoins are increasingly used for cross-border merchant settlement,
+particularly in emerging markets where traditional banking rails are slow or
+expensive. AP2 mandates could provide the accountability and audit trail
+needed for these transactions.
+## Possible PaymentMethodData Extension
+One possible approach to supporting stablecoins is to define a payment method
+identifier following the W3C Payment Method convention. For example:
+```json
+{
+  "supported_methods": "https://example.com/stablecoin/v1",
+  "data": {
+    "supported_tokens": ["USDT", "USDC"],
+    "supported_chains": ["ethereum", "tron", "polygon"],
+    "preferred_chain": "tron",
+    "settlement_currency": "USD"
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
       - Core Concepts: topics/core-concepts.md
       - AP2, A2A and MCP: topics/ap2-a2a-and-mcp.md
       - AP2 and x402: topics/ap2-and-x402.md
+      - Exploring Stablecoin Payments: topics/ap2-and-stablecoin-payments.md
       - Privacy and Security: topics/privacy-and-security.md
       - Life of a Transaction: topics/life-of-a-transaction.md
   - AP2 specification: specification.md


### PR DESCRIPTION
## Add Stablecoin Payments Documentation
This document explores how AP2 could be applied to stablecoin-based push payments, covering:
- Push vs pull payment semantics and a conceptual mapping of how AP2 mandates might function in a stablecoin context
- Potential use cases: social entertainment payments (tipping, gifting, subscriptions) and cross-border B2B settlement
- An illustrative example of a PaymentMethodData extension for stablecoins
- A conceptual gap analysis between current AP2 v0.1 capabilities and stablecoin payment needs
- Alignment with the AP2 roadmap (e.g., push payments and recurring payments planned for future versions)
- Relationship to x402
This follows the existing pattern of topic documents such as `ap2-and-x402.md` and `ap2-and-ucp.md`.
This document is intended as an exploratory contribution and does not represent an official AP2 specification.
- [x] Follow the CONTRIBUTING Guide
- [x] Make your Pull Request title in the conventional commits specification
- [x] Appropriate docs were updated