### PR TITLE
docs: fix API key name in digital-payment-credentials README

### DIFF
--- a/samples/android/scenarios/digital-payment-credentials/README.md
+++ b/samples/android/scenarios/digital-payment-credentials/README.md
@@ -47,10 +47,11 @@ This sample consists of:
         export GOOGLE_API_KEY=your_key
         ```
 
-    1.  Add it to the local.properties file.
+    1.  Add it to the local.properties file. Note: the Android app reads
+        `GEMINI_API_KEY` from this file.
 
         ```
-        echo "GOOGLE_API_KEY=your_key" >> samples/android/shopping_assistant/local.properties
+        echo "GEMINI_API_KEY=your_key" >> samples/android/shopping_assistant/local.properties
         ```
 
 3.  **Add the Android SDK path to the local.properties file.**


### PR DESCRIPTION
## Summary
- The README instructed users to set `GOOGLE_API_KEY` in `local.properties`, but `build.gradle.kts` reads `GEMINI_API_KEY`. This mismatch caused a 403 PERMISSION_DENIED error when the Android app called the Gemini API with an empty key.
- Updated the README to use `GEMINI_API_KEY` for `local.properties`

## Test plan
- [x] Followed the updated README instructions with `GEMINI_API_KEY` in `local.properties`
- [x] Verified the Android app successfully calls the Gemini API without 403 errors

Fixes #204