### PR TITLE
fix(python-samples): sanitize payment credential responses

### DIFF
--- a/samples/python/src/roles/credentials_provider_agent/account_manager.py
+++ b/samples/python/src/roles/credentials_provider_agent/account_manager.py
@@ -236,6 +236,8 @@ def get_payment_method_processing_details(
   exposing card data.
   """
   payment_method = verify_token(token, payment_mandate_id, payer_email)
+  if not payment_method:
+    return None
   processor_details = {
       "type": payment_method.get("type"),
       "alias": payment_method.get("alias"),

--- a/samples/python/src/roles/credentials_provider_agent/account_manager.py
+++ b/samples/python/src/roles/credentials_provider_agent/account_manager.py
@@ -111,6 +111,14 @@ _account_db = {
 _token = {}
 
 
+def _get_token_lookup(token: str) -> dict[str, Any]:
+  """Returns the token metadata for the given token."""
+  account_lookup = _token.get(token, {})
+  if not account_lookup:
+    raise ValueError("Invalid token")
+  return account_lookup
+
+
 def create_token(
     email_address: str, payment_method_alias: str
 ) -> str | dict[str, Any]:
@@ -171,32 +179,78 @@ def update_token(token: str, payment_mandate_id: str) -> None:
     token: The token to update.
     payment_mandate_id: The payment mandate id to associate with the token.
   """
-  if token not in _token:
-    raise ValueError(f"Token {token} not found")
-  if _token[token].get("payment_mandate_id"):
+  if not payment_mandate_id:
+    raise ValueError("payment_mandate_id is required")
+  account_lookup = _get_token_lookup(token)
+  if account_lookup.get("payment_mandate_id"):
     # Do not overwrite the payment mandate id if it is already set.
     return
   _token[token]["payment_mandate_id"] = payment_mandate_id
 
-def verify_token(token: str, payment_mandate_id: str) -> dict[str, Any]:
+
+def validate_token_payer(token: str, payer_email: str) -> None:
+  """Ensures the token was issued for the payer email in the mandate."""
+  if not payer_email:
+    raise ValueError("payer_email is required")
+  account_lookup = _get_token_lookup(token)
+  if account_lookup.get("email_address") != payer_email:
+    raise ValueError("Invalid token")
+
+
+def verify_token(
+    token: str,
+    payment_mandate_id: str,
+    payer_email: str | None = None,
+) -> dict[str, Any]:
   """Look up an account by token.
 
   Args:
     token: The token for look up.
     payment_mandate_id: The payment mandate id associated with the token.
+    payer_email: The email address presented in the payment mandate.
 
   Returns:
     The account for the given token, or status:invalid_token if the token is not
     valid.
   """
-  account_lookup = _token.get(token, {})
-  if not account_lookup:
-    raise ValueError("Invalid token")
+  account_lookup = _get_token_lookup(token)
   if account_lookup.get("payment_mandate_id") != payment_mandate_id:
+    raise ValueError("Invalid token")
+  if payer_email and account_lookup.get("email_address") != payer_email:
     raise ValueError("Invalid token")
   email_address = account_lookup.get("email_address")
   alias = account_lookup.get("payment_method_alias")
   return get_payment_method_by_alias(email_address, alias)
+
+
+def get_payment_method_processing_details(
+    token: str,
+    payment_mandate_id: str,
+    payer_email: str | None = None,
+) -> dict[str, Any]:
+  """Returns processor-safe payment method metadata for the given token.
+
+  The sample merchant payment processor does not need the raw wallet-held
+  credential material. Keep the response limited to non-sensitive method
+  metadata plus an opaque reference that can be logged or handed off without
+  exposing card data.
+  """
+  payment_method = verify_token(token, payment_mandate_id, payer_email)
+  processor_details = {
+      "type": payment_method.get("type"),
+      "alias": payment_method.get("alias"),
+      "credential_reference": {
+          "payment_credential_token": token,
+          "payment_mandate_id": payment_mandate_id,
+      },
+  }
+
+  if payment_method.get("network"):
+    processor_details["network"] = payment_method["network"]
+  if payment_method.get("brand"):
+    processor_details["brand"] = payment_method["brand"]
+
+  return processor_details
 
 
 def get_account_payment_methods(email_address: str) -> list[dict[str, Any]]:

--- a/samples/python/src/roles/credentials_provider_agent/account_manager.py
+++ b/samples/python/src/roles/credentials_provider_agent/account_manager.py
@@ -185,7 +185,7 @@ def update_token(token: str, payment_mandate_id: str) -> None:
   if account_lookup.get("payment_mandate_id"):
     # Do not overwrite the payment mandate id if it is already set.
     return
-  _token[token]["payment_mandate_id"] = payment_mandate_id
+  account_lookup["payment_mandate_id"] = payment_mandate_id
 
 
 def validate_token_payer(token: str, payer_email: str) -> None:

--- a/samples/python/src/roles/credentials_provider_agent/account_manager.py
+++ b/samples/python/src/roles/credentials_provider_agent/account_manager.py
@@ -227,7 +227,7 @@ def get_payment_method_processing_details(
     token: str,
     payment_mandate_id: str,
     payer_email: str | None = None,
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
   """Returns processor-safe payment method metadata for the given token.
 
   The sample merchant payment processor does not need the raw wallet-held

--- a/samples/python/src/roles/credentials_provider_agent/account_manager.py
+++ b/samples/python/src/roles/credentials_provider_agent/account_manager.py
@@ -201,7 +201,7 @@ def verify_token(
     token: str,
     payment_mandate_id: str,
     payer_email: str | None = None,
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
   """Look up an account by token.
 
   Args:

--- a/samples/python/src/roles/credentials_provider_agent/tools.py
+++ b/samples/python/src/roles/credentials_provider_agent/tools.py
@@ -105,9 +105,10 @@ async def handle_get_payment_method_raw_credentials(
     updater: TaskUpdater,
     current_task: Task | None,
 ) -> None:
-  """Exchanges a payment token for the payment method's raw credentials.
+  """Exchanges a payment token for sample-safe processor payment details.
 
-  Updates a task with the payment credentials.
+  Updates a task with non-sensitive payment method metadata. The sample keeps
+  raw wallet-held credential material inside the credentials provider.
 
   Args:
     data_parts: DataPart contents. Should contain a single PaymentMandate.
@@ -123,8 +124,11 @@ async def handle_get_payment_method_raw_credentials(
       "token", {}
   ).get("value", "")
   payment_mandate_id = payment_mandate_contents.payment_mandate_id
+  payer_email = payment_mandate_contents.payment_response.payer_email
 
-  payment_method = account_manager.verify_token(token, payment_mandate_id)
+  payment_method = account_manager.get_payment_method_processing_details(
+      token, payment_mandate_id, payer_email
+  )
   if not payment_method:
     raise ValueError(f"Payment method not found for token: {token}")
   await updater.add_artifact([Part(root=DataPart(data=payment_method))])
@@ -198,6 +202,12 @@ async def handle_signed_payment_mandate(
   payment_mandate_id = (
       payment_mandate.payment_mandate_contents.payment_mandate_id
   )
+  payer_email = (
+      payment_mandate.payment_mandate_contents.payment_response.payer_email
+  )
+  if not payer_email:
+    raise ValueError("payer_email is required in PaymentMandate.")
+  account_manager.validate_token_payer(token, payer_email)
   account_manager.update_token(token, payment_mandate_id)
   await updater.complete()
 

--- a/samples/python/src/roles/merchant_payment_processor_agent/tools.py
+++ b/samples/python/src/roles/merchant_payment_processor_agent/tools.py
@@ -196,10 +196,14 @@ async def _complete_payment(
       payment_method,
   )
 
+  credential_reference = {}
+  if isinstance(payment_credential, dict):
+    credential_reference = payment_credential.get("credential_reference", {})
+
   logging.info(
-      "Calling issuer to complete payment for %s with payment credential %s...",
+      "Calling issuer to complete payment for %s with credential reference %s...",
       payment_mandate_id,
-      payment_credential,
+      credential_reference,
   )
   # Call issuer to complete the payment
   payment_receipt = _create_payment_receipt(payment_mandate)

--- a/samples/python/tests/test_credentials_provider_security.py
+++ b/samples/python/tests/test_credentials_provider_security.py
@@ -1,0 +1,130 @@
+import os
+import sys
+import types as _types
+import unittest
+
+
+ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+SAMPLES_SRC = os.path.join(ROOT, "samples", "python", "src")
+AP2_SRC = os.path.join(ROOT, "src")
+sys.path.insert(0, SAMPLES_SRC)
+sys.path.insert(0, AP2_SRC)
+
+
+if "x402_a2a" not in sys.modules:
+  _x402 = _types.ModuleType("x402_a2a")
+  _x402_types = _types.ModuleType("x402_a2a.types")
+  _x402_types.EIP3009Authorization = type("EIP3009Authorization", (), {})
+  _x402_types.ExactPaymentPayload = type("ExactPaymentPayload", (), {})
+  _x402_types.PaymentPayload = type("PaymentPayload", (), {})
+  _x402.types = _x402_types
+  sys.modules["x402_a2a"] = _x402
+  sys.modules["x402_a2a.types"] = _x402_types
+
+
+from ap2.types.mandate import PAYMENT_MANDATE_DATA_KEY
+from ap2.types.mandate import PaymentMandate
+from ap2.types.mandate import PaymentMandateContents
+from ap2.types.payment_request import PaymentCurrencyAmount
+from ap2.types.payment_request import PaymentItem
+from ap2.types.payment_request import PaymentResponse
+from roles.credentials_provider_agent import account_manager
+from roles.credentials_provider_agent import tools
+
+
+class _FakeUpdater:
+
+  def __init__(self):
+    self.artifacts = []
+    self.completed = False
+
+  async def add_artifact(self, parts):
+    self.artifacts.append(parts)
+
+  async def complete(self, message=None):
+    self.completed = True
+
+
+def _build_payment_mandate(token: str, payer_email: str) -> PaymentMandate:
+  return PaymentMandate(
+      payment_mandate_contents=PaymentMandateContents(
+          payment_mandate_id="test-payment-mandate",
+          payment_details_id="order-1",
+          payment_details_total=PaymentItem(
+              label="Total",
+              amount=PaymentCurrencyAmount(currency="USD", value=1.0),
+          ),
+          payment_response=PaymentResponse(
+              request_id="order-1",
+              method_name="CARD",
+              details={
+                  "token": {
+                      "value": token,
+                      "url": "http://localhost:8002/a2a/credentials_provider",
+                  }
+              },
+              payer_email=payer_email,
+          ),
+          merchant_agent="Generic Merchant",
+      ),
+      user_authorization="fake_cart_mandate_hash_cart_1_fake_payment_mandate_hash_test-payment-mandate",
+  )
+
+
+class CredentialsProviderSecurityTest(unittest.IsolatedAsyncioTestCase):
+
+  async def asyncSetUp(self):
+    account_manager._token.clear()
+
+  async def test_processor_details_are_sanitized(self):
+    token = account_manager.create_token(
+        "bugsbunny@gmail.com", "American Express ending in 4444"
+    )
+    mandate = _build_payment_mandate(token, "bugsbunny@gmail.com")
+
+    bind_updater = _FakeUpdater()
+    await tools.handle_signed_payment_mandate(
+        [{PAYMENT_MANDATE_DATA_KEY: mandate.model_dump()}],
+        bind_updater,
+        None,
+    )
+
+    raw_updater = _FakeUpdater()
+    await tools.handle_get_payment_method_raw_credentials(
+        [{PAYMENT_MANDATE_DATA_KEY: mandate.model_dump()}],
+        raw_updater,
+        None,
+    )
+    returned_data = raw_updater.artifacts[0][0].root.data
+
+    self.assertEqual(returned_data["type"], "CARD")
+    self.assertEqual(
+        returned_data["alias"], "American Express ending in 4444"
+    )
+    self.assertEqual(
+        returned_data["credential_reference"]["payment_credential_token"], token
+    )
+    self.assertNotIn("token", returned_data)
+    self.assertNotIn("cryptogram", returned_data)
+    self.assertNotIn("card_holder_name", returned_data)
+    self.assertNotIn("card_expiration", returned_data)
+    self.assertNotIn("card_billing_address", returned_data)
+
+  async def test_signed_mandate_rejects_wrong_payer_email(self):
+    token = account_manager.create_token(
+        "bugsbunny@gmail.com", "American Express ending in 4444"
+    )
+    mandate = _build_payment_mandate(token, "daffyduck@gmail.com")
+
+    with self.assertRaisesRegex(ValueError, "Invalid token"):
+      await tools.handle_signed_payment_mandate(
+          [{PAYMENT_MANDATE_DATA_KEY: mandate.model_dump()}],
+          _FakeUpdater(),
+          None,
+      )
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
- keep raw wallet-held credential material inside the credentials provider
- return sample-safe processor metadata plus an opaque `credential_reference`
- validate that the payment mandate payer matches the token owner before binding
- stop logging the full payment credential object in the sample payment processor
- add regression tests for sanitized responses and payer/token mismatch rejection

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google-agentic-commerce/AP2?tab=contributing-ov-file#how-to-contribute).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [ ] Ensure the tests and linter pass
- [ ] Appropriate docs were updated (if necessary)

