### PR TITLE
docs: add Panya.health to partner directory

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -119,6 +119,7 @@ otelhttp
 Otherville
 OURCYGPATTERN
 Palo
+Panya
 passcodes
 Paynet
 Payoneer

--- a/docs/partners.md
+++ b/docs/partners.md
@@ -81,6 +81,7 @@ build, codify, and adopt A2A as the standard protocol for AI agent payments.
 - [Okta](https://www.okta.com/)
 - [OKX](https://www.okx.com/)
 - [Palo Alto Networks](https://www.paloaltonetworks.com/)
+- [Panya.health](https://panya.health/)
 - [Paxos](https://www.paxos.com/)
 - [Paynet](https://www.paynet.ro/)
 - [Payoneer](https://www.payoneer.com/)


### PR DESCRIPTION
## Add Panya.health to partner directory

Panya.health is a trust-first peptide guidance and vendor-matching platform. Adding to the partner directory per AP2's open partner-listing process.

### Integration summary

- **AP2 v0.1 CartMandate issuance** — every product entry in our ACP feed at `/api/acp/products.json` ships a fresh signed CartMandate per request with 10-minute TTL.
- **Discovery** — `/.well-known/ap2.json` (issuer metadata) and `/.well-known/ap2-jwks.json` (RFC 7517 JWKS, Ed25519 public key, `kid: panya-ap2-v1`).
- **Verification** — `POST /api/ap2/verify` accepts a CartMandate and returns a structured verify result (signature, iss, sub, exp, iat, cart_hash).
- **MCP server** — `/api/mcp` exposes three tools that any AP2-compatible agent can call to discover and cite vendors (`panya.match_vendor`, `panya.list_protocols`, `panya.cite`).

### Test endpoints (live)

- `curl https://panya.health/.well-known/ap2.json` → issuer metadata
- `curl https://panya.health/.well-known/ap2-jwks.json` → public JWKS
- `curl https://panya.health/api/acp/products.json` → ACP feed with signed CartMandates (3 products)
- `curl -X POST https://panya.health/api/ap2/verify -H 'content-type: application/json' -d @cart-mandate.json` → returns `valid: true, key_status: production, cart_hash_matches: true`

### Key choices, in case useful for spec discussion

- **Ed25519 over RSA / ECDSA P-256** — Node native, short keys, deterministic signatures, performance.
- **JWS compact serialization** — standard AP2 transport.
- **Canonical JSON via sort-key stringify** — RFC 8785 not referenced in AP2 v0.1 spec; happy to switch if the spec adopts a canonical form.
- **`/.well-known/ap2.json` discovery path** — Panya-internal convention. AP2 spec section 9 lists discovery as an open problem. We'd realign to whatever convention AP2 picks.

Happy to adjust formatting, copy, or section placement to match the existing directory style. Thanks for the work on AP2.
