### PR TITLE
docs(partners): add Semore — Korea-first 5-protocol multi-adapter reference implementation

### DIFF
--- a/docs/partners.md
+++ b/docs/partners.md
@@ -98,6 +98,7 @@ build, codify, and adopt A2A as the standard protocol for AI agent payments.
 - [Riskified](https://www.riskified.com/)
 - [Salesforce](https://www.salesforce.com/)
 - [Sardine](https://www.sardine.ai/)
+- [Semore](https://semore.net/)
 - [ServiceNow](https://www.servicenow.com/)
 - [Shopee](https://shopee.com/)
 - [Shopify](https://www.shopify.com/)


### PR DESCRIPTION
## Summary

Adds **Semore** to `docs/partners.md` as a vertical reference implementation of AP2 focused on Korean cross-border K-product agentic commerce.

Semore is the first Korea-anchored adopter implementing the **full AP2 mandate VC chain** (IntentMandate / CartMandate / PaymentMandate) using **Ed25519 + JCS canonicalization** as the native signature path, with **SD-JWT-VC** selective disclosure shipped as a dual-lane LIVE in production.

## Scope

- 5-protocol multi-adapter ref impl: **AP2 + ACP + MCP + UCP** (+ Visa TAP track in flight)
- Hybrid PSP routing: **Stripe Connect (overseas)** + **KCP direct (Korea)** — per internal ADR-0072 / ADR-0074
- Domain: K-beauty / K-fashion / K-pop merchandise, agent-driven cross-border purchase in a single conversation
- Apache-2.0 OSS across all adapter packages

## Public artifacts

| Artifact | Location |
|---|---|
| npm scope | `@semore/{ap2-adapter, mcp-commerce, acp-adapter, ucp-adapter}` |
| GitHub org | https://github.com/semorehq |
| MCP Registry | `io.github.semorehq/mcp-commerce@0.4.2` (Korea's first commerce MCP entry) |
| DID | `did:web:semore.net` (Ed25519 mandate signing key) |
| Site | https://semore.net |
| Contact | semore.hq@gmail.com |

## Compliance

- [x] Google Individual CLA signed (2026-04-28)
- [x] Apache-2.0 license compatible
- [x] Alphabetical ordering preserved (Sardine → **Semore** → ServiceNow)
- [x] Single-line addition, matches existing entry format

## Test plan

- [x] Verified `docs/partners.md` renders correctly (1-line bullet, hyperlink resolves)
- [x] `https://semore.net/` resolves (200 OK)
- [x] No formatting drift in surrounding entries

---

Signed-off-by: Semore Founding Team