### PR TITLE
docs(spec): fix three doubled-article typos in AP2 specification

### DIFF
--- a/docs/ap2/specification.md
+++ b/docs/ap2/specification.md
@@ -123,7 +123,7 @@ assembled.
 The Checkout Mandate is provided by the Shopping Agent and verified by the
 Merchant.
 
-The The Merchant MUST provide a merchant-signed JWT containing the Checkout to
+The Merchant MUST provide a merchant-signed JWT containing the Checkout to
 the Shopping Agent. The closed Checkout Mandate is bound to this Checkout JWT
 using a cryptographic hash.
 
@@ -197,11 +197,11 @@ a Trusted Surface for display to the user and signing.
 
 Upon receiving the Checkout and Payment Mandate, the Shopping Agent forwards the
 Payment Mandate to the Credential Provider (and possibly the Network) for
-Verification. Upon successful verification, the the Shopping Agent receives a
+Verification. Upon successful verification, the Shopping Agent receives a
 payment credential.
 
 The payment credential and a Checkout Mandate are then provided to the Merchant.
-The The Merchant verifies the Checkout with what it created, and initiates
+The Merchant verifies the Checkout with what it created, and initiates
 payment with the Merchant Payment Processor if a Merchant-initiated charge.
 
 In the case that the payment method pushes funds to the Merchant, the Merchant

--- a/docs/ap2/specification.md
+++ b/docs/ap2/specification.md
@@ -197,7 +197,7 @@ a Trusted Surface for display to the user and signing.
 
 Upon receiving the Checkout and Payment Mandate, the Shopping Agent forwards the
 Payment Mandate to the Credential Provider (and possibly the Network) for
-Verification. Upon successful verification, the Shopping Agent receives a
+verification. Upon successful verification, the Shopping Agent receives a
 payment credential.
 
 The payment credential and a Checkout Mandate are then provided to the Merchant.


### PR DESCRIPTION
## Summary

Three occurrences of a repeated article (\"The The\" / \"the the\") in `docs/ap2/specification.md`:

- L126: \"The The Merchant MUST provide a merchant-signed JWT...\"
- L200: \"...verification, the the Shopping Agent receives...\"
- L204: \"The The Merchant verifies the Checkout...\"

Pure typo fix. No semantic changes.

## Changes

- `docs/ap2/specification.md` — 3 lines, 3 doubled-article corrections.