### PR TITLE
docs: fix AP2 documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,12 +153,12 @@ generally follow this pattern:
 ### Installing the AP2 Types Package
 
 The protocol's core objects are defined under
-[`code/sdk/python/ap2/`](code/sdk/python/ap2/) — Pydantic models in
-[`models/`](code/sdk/python/ap2/models/) and
-[`sdk/generated/`](code/sdk/python/ap2/sdk/generated/), canonical JSON schemas
-in [`schemas/`](code/sdk/python/ap2/schemas/). A PyPI package will be published
-at a later time. Until then, you can install the package directly using this
-command:
+[`code/sdk/`](code/sdk/) — canonical JSON schemas in
+[`schemas/`](code/sdk/schemas/), Pydantic models in
+[`python/ap2/models/`](code/sdk/python/ap2/models/), and generated Python models
+in [`python/ap2/sdk/generated/`](code/sdk/python/ap2/sdk/generated/). A PyPI
+package will be published at a later time. Until then, you can install the
+package directly using this command:
 
 ```sh
 uv pip install git+https://github.com/google-agentic-commerce/AP2.git@main

--- a/code/README.md
+++ b/code/README.md
@@ -12,7 +12,7 @@ It contains:
 
 - `sdk/python/ap2/models/` — Pydantic models for carts, mandates, receipts,
   and payment requests.
-- `sdk/python/ap2/schemas/` — canonical JSON Schemas and the generator used
+- `sdk/schemas/` — canonical JSON Schemas and the generator used
   to emit the Python models in `sdk/python/ap2/sdk/generated/`.
 - `sdk/python/ap2/sdk/` — the runtime SDK: mandate wrappers, chain
   verification, SD-JWT helpers, constraints, disclosure metadata.

--- a/code/samples/go/scenarios/a2a/human-present/cards/README.md
+++ b/code/samples/go/scenarios/a2a/human-present/cards/README.md
@@ -272,9 +272,9 @@ If running manually, stop each process individually.
 
 ## Resources
 
-- [AP2 Protocol Documentation](../../../../README.md)
-- [Python Sample (with Shopping Agent)](../../../../python/scenarios/a2a/human-present/cards/README.md)
-- [Go Implementation Guide](../../README.md)
+- [AP2 Protocol Documentation](../../../../../../../README.md)
+- [Python Sample (with Shopping Agent)](../../../../../python/scenarios/a2a/human-present/cards/README.md)
+- [Go Implementation Guide](../../../../README.md)
 
 ## License
 


### PR DESCRIPTION
# Description

Fixes a few stale documentation links in the AP2 repository:

- Updates the SDK schema references to point to `code/sdk/schemas/`, where the canonical JSON schemas currently live.
- Fixes resource links in the Go human-present card sample so they resolve to the root AP2 docs, the Python sample, and the Go implementation guide.

# Validation

- Ran a focused local Markdown link check on the changed files.
- Confirmed all changed links resolve locally.