### PR TITLE
docs: fix AP2 diagram asset paths

### DIFF
--- a/docs/ap2/agent_authorization.md
+++ b/docs/ap2/agent_authorization.md
@@ -22,11 +22,11 @@ The authorization process is broken into two steps:
 
 <div style="display: flex; justify-content: space-around;">
   <figure>
-    <img src="../../assets/mandate_delegation_overview.svg" style="width:100%" alt="Diagram illustrating the Mandate Delegation process">
+    <img src="../assets/mandate_delegation_overview.svg" style="width:100%" alt="Diagram illustrating the Mandate Delegation process">
     <figcaption align="center">Mandate Delegation</figcaption>
   </figure>
   <figure>
-    <img src="../../assets/action_authorization_overview.svg" style="width:100%" alt="Diagram illustrating the Action Authorization process">
+    <img src="../assets/action_authorization_overview.svg" style="width:100%" alt="Diagram illustrating the Action Authorization process">
     <figcaption align="center">Action Authorization</figcaption>
   </figure>
 </div>
@@ -79,7 +79,7 @@ to ensure that the Trusted Surface constructs Mandates only after obtaining
 appropriate user consent and authorization.
 
 <figure>
-  <img src="../../assets/mandate_delegation_user_credential.svg" style="width:100%" alt="Mandate Delegation: User Credential">
+  <img src="../assets/mandate_delegation_user_credential.svg" style="width:100%" alt="Mandate Delegation: User Credential">
   <figcaption align="center">Mandate Delegation: User Credential</figcaption>
 </figure>
 
@@ -294,7 +294,7 @@ authorization. This model does not require a pre-issued credential. The
 following steps occur:
 
 <figure>
-  <img src="../../assets/mandate_delegation_trusted_agent_provider.svg" style="width:100%" alt="Mandate Delegation: Trusted Agent Provider">
+  <img src="../assets/mandate_delegation_trusted_agent_provider.svg" style="width:100%" alt="Mandate Delegation: Trusted Agent Provider">
   <figcaption align="center">Mandate Delegation: Trusted Agent Provider</figcaption>
 </figure>
 
@@ -402,7 +402,7 @@ Open Mandates are necessary to allow the Agent to perform autonomous actions on
 the User’s behalf, while still appropriately constraining their behavior.
 
 <figure>
-  <img src="../../assets/mandate_chain_example.svg" style="width:800px" alt="Examples of open and closed Mandate Chains">
+  <img src="../assets/mandate_chain_example.svg" style="width:800px" alt="Examples of open and closed Mandate Chains">
   <figcaption align="center">Example: Mandate Chains</figcaption>
 </figure>
 

--- a/docs/ap2/flows.md
+++ b/docs/ap2/flows.md
@@ -21,7 +21,7 @@ This is the `direct` flow where the User is present to directly approve the
 closed Payment and Checkout Mandates.
 
 <figure>
-  <img src="../../assets/ap2_hp_flow.svg" style="width:800px" alt="Diagram showing the overall Human Present flow in AP2">
+  <img src="../assets/ap2_hp_flow.svg" style="width:800px" alt="Diagram showing the overall Human Present flow in AP2">
   <figcaption align="center">Human Present flow</figcaption>
 </figure>
 
@@ -30,7 +30,7 @@ There are two phases to this flow:
 **Phase 1: Shopping**
 
 <figure>
-  <img src="../../assets/ap2_hp_shopping.svg" style="width:800px" alt="Human Present Shopping flow">
+  <img src="../assets/ap2_hp_shopping.svg" style="width:800px" alt="Human Present Shopping flow">
   <figcaption align="center">Human Present Shopping flow</figcaption>
 </figure>
 
@@ -44,7 +44,7 @@ There are two phases to this flow:
 **Phase 2: Payment**
 
 <figure>
-  <img src="../../assets/ap2_hp_payment.svg" style="width:800px" alt="Human Present Payment flow">
+  <img src="../assets/ap2_hp_payment.svg" style="width:800px" alt="Human Present Payment flow">
   <figcaption align="center">Human Present Payment flow</figcaption>
 </figure>
 
@@ -79,7 +79,7 @@ There are two phases to this flow:
 ## Human Not Present
 
 <figure>
-  <img src="../../assets/ap2_hnp_flow.svg" style="width:800px" alt="Human Not Present flow">
+  <img src="../assets/ap2_hnp_flow.svg" style="width:800px" alt="Human Not Present flow">
   <figcaption align="center">Human Not Present flow</figcaption>
 </figure>
 
@@ -90,7 +90,7 @@ phase, the User sets a shopping task for the Agent. In the second phase, the
 Agent acts autonomously to complete the task without further human interaction.
 
 <figure>
-  <img src="../../assets/ap2_hnp_shopping.svg" style="width:800px" alt="Human Not Present Shopping flow">
+  <img src="../assets/ap2_hnp_shopping.svg" style="width:800px" alt="Human Not Present Shopping flow">
   <figcaption align="center">Human Not Present Shopping flow</figcaption>
 </figure>
 
@@ -132,7 +132,7 @@ the assigned task.
 In this phase, the Agent completes the checkout using the provided Mandates.
 
 <figure>
-  <img src="../../assets/ap2_hnp_payment.svg" style="width:800px" alt="Human Not Present Payment flow">
+  <img src="../assets/ap2_hnp_payment.svg" style="width:800px" alt="Human Not Present Payment flow">
   <figcaption align="center">Human Not Present Payment flow</figcaption>
 </figure>
 


### PR DESCRIPTION
## Summary
- fix image paths in `docs/ap2/agent_authorization.md`
- fix image paths in `docs/ap2/flows.md` so the referenced assets resolve from `docs/ap2/`

## Validation
- verified each updated `../assets/...` target exists under `docs/assets/`
