### PR TITLE
fix(sdk): match allowed payment instruments by (type, id), not id alone

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -118,6 +118,7 @@ okhttp
 opentelemetry
 otelgrpc
 otelhttp
+otherpisp
 Otherville
 OURCYGPATTERN
 Palo
@@ -127,6 +128,10 @@ Payoneer
 paypal
 Payplug
 pids
+PISP
+Pisp
+pisp
+Pisps
 pmezard
 proguard
 Proguard
@@ -149,6 +154,7 @@ ropeproject
 RPCURL
 Rulebook
 screenreaders
+SECP
 setlocal
 sharedpref
 Shopcider

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -23,7 +23,8 @@ jobs:
           LOG_LEVEL: WARN
           SHELLCHECK_OPTS: -e SC1091 -e 2086
           VALIDATE_ALL_CODEBASE: false
-          FILTER_REGEX_EXCLUDE: "^(\\.github/|\\.vscode/|code/samples/).*|CODE_OF_CONDUCT.md|CHANGELOG.md"
+          FILTER_REGEX_EXCLUDE: "^(\\.github/|\\.vscode/|code/samples/|code/web-client/).*|CODE_OF_CONDUCT.md|CHANGELOG.md"
+          VALIDATE_BIOME_LINT: false
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_PYTHON_BLACK: false
           VALIDATE_PYTHON_FLAKE8: false

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  statuses: write
+  pull-requests: write
+
 jobs:
   build:
     name: Lint Code Base
@@ -11,12 +16,13 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v8
+        uses: super-linter/super-linter/slim@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -24,8 +30,8 @@ jobs:
           SHELLCHECK_OPTS: -e SC1091 -e 2086
           VALIDATE_ALL_CODEBASE: false
           FILTER_REGEX_EXCLUDE: "^(\\.github/|\\.vscode/|code/samples/|code/web-client/).*|CODE_OF_CONDUCT.md|CHANGELOG.md"
-          VALIDATE_BIOME_LINT: false
           VALIDATE_BIOME_FORMAT: false
+          VALIDATE_BIOME_LINT: false
           VALIDATE_PYTHON_BLACK: false
           VALIDATE_PYTHON_FLAKE8: false
           VALIDATE_PYTHON_ISORT: false

--- a/code/sdk/python/ap2/sdk/constraints.py
+++ b/code/sdk/python/ap2/sdk/constraints.py
@@ -243,12 +243,20 @@ class AllowedPaymentInstrumentEvaluator(PaymentConstraintEvaluator):
         instrument = closed_mandate.payment_instrument
         if not instrument:
             return ['Missing payment instrument in closed mandate']
+        # Match on both type and id. Matching on id alone lets a closed
+        # instrument of a different type (e.g. {id: 'x', type: 'bank'}) satisfy
+        # an allowed {id: 'x', type: 'card'}, since id uniqueness is not defined
+        # across types. Requiring (type, id) prevents that instrument-type
+        # confusion.
         if any(
-            allowed.id == instrument.id
+            allowed.type == instrument.type and allowed.id == instrument.id
             for allowed in self.constraint.allowed
         ):
             return []
-        return [f'Payment instrument {instrument.id} not in allowed list']
+        return [
+            f'Payment instrument (type={instrument.type}, id={instrument.id}) '
+            'not in allowed list'
+        ]
 
 
 class AllowedPispEvaluator(PaymentConstraintEvaluator):

--- a/code/sdk/python/ap2/tests/constraints_tests.py
+++ b/code/sdk/python/ap2/tests/constraints_tests.py
@@ -412,6 +412,50 @@ def test_payment_allowed_payment_instrument_mismatch():
     assert any('not in allowed list' in v for v in violations)
 
 
+def test_payment_allowed_payment_instrument_same_id_different_type_rejected():
+    """A closed instrument with an allowed id but a different type is rejected.
+
+    id uniqueness is not defined across instrument types, so matching on id
+    alone would let {id: 'pi-1', type: 'bank'} satisfy an allowed
+    {id: 'pi-1', type: 'card'}. Matching requires (type, id).
+    """
+    violations = check_payment_constraints(
+        _open_payment(
+            constraints=[
+                AllowedPaymentInstruments(
+                    allowed=[
+                        PaymentInstrument(id='pi-1', type='card')
+                    ],
+                ),
+            ]
+        ),
+        _closed_payment(
+            payment_instrument=PaymentInstrument(id='pi-1', type='bank')
+        ),
+    )
+    assert any('not in allowed list' in v for v in violations)
+
+
+def test_payment_allowed_payment_instrument_type_and_id_match():
+    """A closed instrument matching an allowed (type, id) passes."""
+    violations = check_payment_constraints(
+        _open_payment(
+            constraints=[
+                AllowedPaymentInstruments(
+                    allowed=[
+                        PaymentInstrument(id='pi-1', type='card'),
+                        PaymentInstrument(id='pi-1', type='bank'),
+                    ],
+                ),
+            ]
+        ),
+        _closed_payment(
+            payment_instrument=PaymentInstrument(id='pi-1', type='bank')
+        ),
+    )
+    assert violations == []
+
+
 # ── check_payment_constraints – budget ───────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Addresses the allowed-instrument matching defect reported in #299 (item 2): the Python evaluator matches an allowed `PaymentInstrument` on `id` alone.

`AllowedPaymentInstrumentEvaluator.evaluate` compared only `allowed.id == instrument.id` ([constraints.py#L246-L251](https://github.com/google-agentic-commerce/AP2/blob/e1ea56db72a6385bce3e5c1112b3a56ce60acb43/code/sdk/python/ap2/sdk/constraints.py#L246-L251)). Because `PaymentInstrument.id` uniqueness is not defined across `type`s, a closed instrument of a different type satisfied the constraint.

## Failure scenario

Allowed set: `[{id: "pi-1", type: "card"}]`. A closed mandate carrying `{id: "pi-1", type: "bank"}` passed the constraint under id-only matching. Where `type` selects the payment profile (or ids are scoped by type / credential provider), a different profile than the one the user authorized could satisfy the `allowed_payment_instrument` constraint, and at minimum inconsistent signed instrument metadata is accepted.

## Fix

Require both `type` and `id` to match, and include `type` in the violation message so a mismatch is diagnosable:

```python
if any(
    allowed.type == instrument.type and allowed.id == instrument.id
    for allowed in self.constraint.allowed
):
    return []
```

## Tests

`code/sdk/python/ap2/tests/constraints_tests.py`:
- `test_payment_allowed_payment_instrument_same_id_different_type_rejected` : same `id`, different `type` is a violation.
- `test_payment_allowed_payment_instrument_type_and_id_match` : an allowed `(type, id)` still passes.

The two existing allowed-instrument tests are unchanged and still pass.

Validated with `pip install .` in a clean `python:3.12-slim` container: `constraints_tests.py` 49 passed.

## Scope

This PR is intentionally limited to the matching semantics. The other two items in #299 are handled separately:

- The x402 sample's fallback-to-a-fixed-amount behavior is fixed in #300 (fail closed on a missing verified amount rather than authorizing `1250`).
- Preserving type-specific instrument fields through parsing and signing (#299 item 1) is a schema and generated-model design decision (`payment_instrument.json` plus the datamodel-codegen output), which I have left for maintainers rather than editing a generated file. Happy to follow up if you want a direction on it.
