### PR TITLE
feat(sdk): add TypeScript SDK for AP2 mandates and receipts

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -185,3 +185,14 @@ XVCJ
 Yapily
 Zalopay
 Zalora
+apidevtools
+subschema
+pisp
+pisps
+Pisp
+PISP
+Mechant
+IDAS
+QWAC
+PKIX
+Genkit

--- a/code/sdk/typescript/.gitignore
+++ b/code/sdk/typescript/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/code/sdk/typescript/README.md
+++ b/code/sdk/typescript/README.md
@@ -1,13 +1,14 @@
 # @ap2-protocol/sdk
 
-TypeScript types and [Zod](https://zod.dev) validation for [Agent Payments
-Protocol](https://ap2-protocol.org) (AP2) mandates and receipts, generated
-directly from the canonical [JSON Schemas](../schemas/ap2) — the same source
-of truth the [Python SDK](../python) is generated from (`ap2/sdk/generated`).
+TypeScript types and [Zod](https://zod.dev) validation for
+[Agent Payments Protocol](https://ap2-protocol.org) (AP2) mandates and receipts,
+generated directly from the canonical [JSON Schemas](../schemas/ap2) — the same
+source of truth the [Python SDK](../python) is generated from
+(`ap2/sdk/generated`).
 
 This package addresses the "provide a generated ... TypeScript library that
-mirrors the AP2 mandate models with validation (e.g. zod)" half of #67. It
-does not yet cover the Python SDK's higher-level `ap2.sdk` helpers (SD-JWT
+mirrors the AP2 mandate models with validation (e.g. zod)" half of #67. It does
+not yet cover the Python SDK's higher-level `ap2.sdk` helpers (SD-JWT
 signing/verification, mandate chain builders, JWT key handling) — see
 [Scope](#scope) below.
 
@@ -20,19 +21,19 @@ npm install @ap2-protocol/sdk
 ## Usage
 
 ```ts
-import { PaymentMandateSchema } from '@ap2-protocol/sdk';
+import { PaymentMandateSchema } from "@ap2-protocol/sdk";
 
 const result = PaymentMandateSchema.safeParse({
-  transaction_id: 'tx_1',
-  payee: { id: 's-1', name: 'Shop' },
-  payment_amount: { amount: 1000, currency: 'USD' },
-  payment_instrument: { id: 'pi-1', type: 'credit' },
+    transaction_id: "tx_1",
+    payee: { id: "s-1", name: "Shop" },
+    payment_amount: { amount: 1000, currency: "USD" },
+    payment_instrument: { id: "pi-1", type: "credit" },
 });
 
 if (result.success) {
-  // result.data is a fully typed PaymentMandate
+    // result.data is a fully typed PaymentMandate
 } else {
-  console.error(result.error.issues);
+    console.error(result.error.issues);
 }
 ```
 
@@ -65,25 +66,25 @@ change — same workflow as `code/sdk/schemas/generate.py` on the Python side.
 ## Known limitations
 
 - **`contains` is not enforced.** `open_checkout_mandate.json` and
-  `open_payment_mandate.json` each use `contains` to require "at least one
-  array element matching a specific alternative" (e.g. an open checkout
-  mandate's `constraints` must include a `checkout.line_items` entry). The
-  underlying [`json-schema-to-zod`](https://github.com/StefanTerdell/json-schema-to-zod)
+  `open_payment_mandate.json` each use `contains` to require "at least one array
+  element matching a specific alternative" (e.g. an open checkout mandate's
+  `constraints` must include a `checkout.line_items` entry). The underlying
+  [`json-schema-to-zod`](https://github.com/StefanTerdell/json-schema-to-zod)
   generator doesn't support `contains`, so it's silently dropped — arrays
-  missing that element currently validate. Flagging rather than
-  hand-patching generated output; a proper fix means extending the generator
-  to emit a `.refine()` for `contains`, which needs its own review.
+  missing that element currently validate. Flagging rather than hand-patching
+  generated output; a proper fix means extending the generator to emit a
+  `.refine()` for `contains`, which needs its own review.
 - **No compile-time narrowing on `oneOf`-branch schemas** (`PaymentReceipt`,
   `CheckoutReceipt`, `OpenPaymentMandate.constraints` entries). These are
   generated as `z.object(...).and(z.any().superRefine(...))`, and Zod/TS
   collapse `T & any` to `any`, so `z.infer` doesn't narrow by the `status` or
-  `type` discriminator. Runtime validation is correct and covered by tests;
-  only static typing is coarser than the other schemas.
+  `type` discriminator. Runtime validation is correct and covered by tests; only
+  static typing is coarser than the other schemas.
 
 ## Scope
 
 This PR ships the mandate/receipt **type and validation layer** — the part of
-#67 explicitly asking for TS types "with validation (e.g. zod)". It
+issue #67 explicitly asking for TS types "with validation (e.g. zod)". It
 deliberately does not port `ap2.sdk`'s SD-JWT signing/verification, mandate
 chain builders (`payment_mandate_chain.py`, `checkout_mandate_chain.py`), or
 JWT/JWK helpers — that's cryptography-sensitive code that deserves its own
@@ -91,5 +92,5 @@ focused PR and review rather than being bundled in behind a types package.
 
 It's also unrelated to `code/samples/typescript` (PR #144): that's a sample
 application (Genkit + A2A agents) with its own inline, non-reusable schema
-definitions. This package is the standalone, publishable library #67 asks
-for; the sample could migrate to depend on it in a follow-up.
+definitions. This package is the standalone, publishable library #67 asks for;
+the sample could migrate to depend on it in a follow-up.

--- a/code/sdk/typescript/README.md
+++ b/code/sdk/typescript/README.md
@@ -1,0 +1,95 @@
+# @ap2-protocol/sdk
+
+TypeScript types and [Zod](https://zod.dev) validation for [Agent Payments
+Protocol](https://ap2-protocol.org) (AP2) mandates and receipts, generated
+directly from the canonical [JSON Schemas](../schemas/ap2) — the same source
+of truth the [Python SDK](../python) is generated from (`ap2/sdk/generated`).
+
+This package addresses the "provide a generated ... TypeScript library that
+mirrors the AP2 mandate models with validation (e.g. zod)" half of #67. It
+does not yet cover the Python SDK's higher-level `ap2.sdk` helpers (SD-JWT
+signing/verification, mandate chain builders, JWT key handling) — see
+[Scope](#scope) below.
+
+## Install
+
+```sh
+npm install @ap2-protocol/sdk
+```
+
+## Usage
+
+```ts
+import { PaymentMandateSchema } from '@ap2-protocol/sdk';
+
+const result = PaymentMandateSchema.safeParse({
+  transaction_id: 'tx_1',
+  payee: { id: 's-1', name: 'Shop' },
+  payment_amount: { amount: 1000, currency: 'USD' },
+  payment_instrument: { id: 'pi-1', type: 'credit' },
+});
+
+if (result.success) {
+  // result.data is a fully typed PaymentMandate
+} else {
+  console.error(result.error.issues);
+}
+```
+
+Every schema exports both a Zod validator (`FooSchema`) and its inferred
+TypeScript type (`Foo`):
+
+- `PaymentMandateSchema` / `PaymentMandate`
+- `CheckoutMandateSchema` / `CheckoutMandate`
+- `OpenPaymentMandateSchema` / `OpenPaymentMandate`
+- `OpenCheckoutMandateSchema` / `OpenCheckoutMandate`
+- `PaymentReceiptSchema` / `PaymentReceipt`
+- `CheckoutReceiptSchema` / `CheckoutReceipt`
+- `AmountSchema`, `MerchantSchema`, `PispSchema`, `PaymentInstrumentSchema`,
+  `JwkSchema`, `ItemSchema`, `ReceiptStatusSchema` (shared types)
+
+## Regenerating
+
+The schemas under `src/generated/` are generated, not hand-written:
+
+```sh
+npm run generate
+```
+
+This reads every schema in [`code/sdk/schemas/ap2`](../schemas/ap2) and
+[`code/sdk/schemas/ap2/types`](../schemas/ap2/types), dereferences their
+`$ref`s, and emits a matching Zod schema + type per file. Run it whenever the
+JSON Schemas change, then commit the regenerated output alongside your schema
+change — same workflow as `code/sdk/schemas/generate.py` on the Python side.
+
+## Known limitations
+
+- **`contains` is not enforced.** `open_checkout_mandate.json` and
+  `open_payment_mandate.json` each use `contains` to require "at least one
+  array element matching a specific alternative" (e.g. an open checkout
+  mandate's `constraints` must include a `checkout.line_items` entry). The
+  underlying [`json-schema-to-zod`](https://github.com/StefanTerdell/json-schema-to-zod)
+  generator doesn't support `contains`, so it's silently dropped — arrays
+  missing that element currently validate. Flagging rather than
+  hand-patching generated output; a proper fix means extending the generator
+  to emit a `.refine()` for `contains`, which needs its own review.
+- **No compile-time narrowing on `oneOf`-branch schemas** (`PaymentReceipt`,
+  `CheckoutReceipt`, `OpenPaymentMandate.constraints` entries). These are
+  generated as `z.object(...).and(z.any().superRefine(...))`, and Zod/TS
+  collapse `T & any` to `any`, so `z.infer` doesn't narrow by the `status` or
+  `type` discriminator. Runtime validation is correct and covered by tests;
+  only static typing is coarser than the other schemas.
+
+## Scope
+
+This PR ships the mandate/receipt **type and validation layer** — the part of
+#67 explicitly asking for TS types "with validation (e.g. zod)". It
+deliberately does not port `ap2.sdk`'s SD-JWT signing/verification, mandate
+chain builders (`payment_mandate_chain.py`, `checkout_mandate_chain.py`), or
+JWT/JWK helpers — that's cryptography-sensitive code that deserves its own
+focused PR and review rather than being bundled in behind a types package.
+
+It's also unrelated to `code/samples/typescript` (PR #144): that's a sample
+application (Genkit + A2A agents) with its own inline, non-reusable schema
+definitions. This package is the standalone, publishable library #67 asks
+for; the sample could migrate to depend on it in a follow-up.

--- a/code/sdk/typescript/eslint.config.js
+++ b/code/sdk/typescript/eslint.config.js
@@ -1,0 +1,17 @@
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  { ignores: ['dist', 'node_modules', 'src/generated'] },
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['**/*.ts'],
+    rules: {
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        { prefer: 'type-imports', fixStyle: 'separate-type-imports' },
+      ],
+    },
+  },
+);

--- a/code/sdk/typescript/eslint.config.js
+++ b/code/sdk/typescript/eslint.config.js
@@ -1,17 +1,17 @@
-import eslint from '@eslint/js';
-import tseslint from 'typescript-eslint';
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ['dist', 'node_modules', 'src/generated'] },
+  { ignores: ["dist", "node_modules", "src/generated"] },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   {
-    files: ['**/*.ts'],
+    files: ["**/*.ts"],
     rules: {
-      '@typescript-eslint/consistent-type-imports': [
-        'error',
-        { prefer: 'type-imports', fixStyle: 'separate-type-imports' },
+      "@typescript-eslint/consistent-type-imports": [
+        "error",
+        { prefer: "type-imports", fixStyle: "separate-type-imports" },
       ],
     },
-  },
+  }
 );

--- a/code/sdk/typescript/package-lock.json
+++ b/code/sdk/typescript/package-lock.json
@@ -1,0 +1,4643 @@
+{
+  "name": "@ap2-protocol/sdk",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@ap2-protocol/sdk",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
+      "devDependencies": {
+        "@apidevtools/json-schema-ref-parser": "^15.5.0",
+        "@eslint/js": "^9.39.5",
+        "@types/node": "^26.1.1",
+        "eslint": "^9.39.5",
+        "json-schema-to-zod": "^2.8.1",
+        "prettier": "^3.9.6",
+        "tsup": "^8.5.1",
+        "tsx": "^4.23.1",
+        "typescript": "^5.5.3",
+        "typescript-eslint": "^8.65.0",
+        "vitest": "^4.1.10"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-15.5.0.tgz",
+      "integrity": "sha512-Ps4w0FwrDoeVK6hfYxWkVbkmxm+zN+6xoXF2ZfEhfiox0ZNbcSAiUWO6iAIvP5bc3DB270r+EaKcoT1IUyzfxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@types/json-schema": "^7.0.15"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.65.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-to-zod": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-zod/-/json-schema-to-zod-2.8.1.tgz",
+      "integrity": "sha512-fRr1mHgZ7hboLKBUdR428gd9dIHUFGivUqOeiDcSmyXkNZCtB1uGaZLvsjZ4GaN5pwBIs+TGIOf6s+Rp5/R/zA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "json-schema-to-zod": "dist/cjs/cli.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/code/sdk/typescript/package.json
+++ b/code/sdk/typescript/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@ap2-protocol/sdk",
+  "version": "0.1.0",
+  "description": "TypeScript types and Zod validation for Agent Payments Protocol (AP2) mandates, generated from the canonical AP2 JSON Schemas.",
+  "type": "module",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/google-agentic-commerce/AP2/tree/main/code/sdk/typescript",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/google-agentic-commerce/AP2.git",
+    "directory": "code/sdk/typescript"
+  },
+  "keywords": [
+    "ap2",
+    "agent-payments-protocol",
+    "agentic-commerce",
+    "mandate",
+    "zod"
+  ],
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "generate": "tsx scripts/generate.ts",
+    "build": "tsup src/index.ts --format esm,cjs --dts --clean",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@apidevtools/json-schema-ref-parser": "^15.5.0",
+    "@eslint/js": "^9.39.5",
+    "@types/node": "^26.1.1",
+    "eslint": "^9.39.5",
+    "json-schema-to-zod": "^2.8.1",
+    "prettier": "^3.9.6",
+    "tsup": "^8.5.1",
+    "tsx": "^4.23.1",
+    "typescript": "^5.5.3",
+    "typescript-eslint": "^8.65.0",
+    "vitest": "^4.1.10"
+  }
+}

--- a/code/sdk/typescript/scripts/generate.ts
+++ b/code/sdk/typescript/scripts/generate.ts
@@ -3,19 +3,26 @@
 // code/sdk/schemas/generate.py on the Python side, so the TS SDK can't drift
 // from the protocol's source of truth. Run via `npm run generate`.
 
-import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
-import os from 'node:os';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import $RefParser from '@apidevtools/json-schema-ref-parser';
-import { jsonSchemaToZod } from 'json-schema-to-zod';
-import prettier from 'prettier';
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import $RefParser from "@apidevtools/json-schema-ref-parser";
+import { jsonSchemaToZod } from "json-schema-to-zod";
+import prettier from "prettier";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const SCHEMAS_DIR = path.resolve(__dirname, '../../schemas/ap2');
-const TYPES_DIR = path.join(SCHEMAS_DIR, 'types');
-const OUT_TYPES_DIR = path.resolve(__dirname, '../src/generated/types');
-const OUT_MANDATES_DIR = path.resolve(__dirname, '../src/generated/mandates');
+const SCHEMAS_DIR = path.resolve(__dirname, "../../schemas/ap2");
+const TYPES_DIR = path.join(SCHEMAS_DIR, "types");
+const OUT_TYPES_DIR = path.resolve(__dirname, "../src/generated/types");
+const OUT_MANDATES_DIR = path.resolve(__dirname, "../src/generated/mandates");
 
 // Each schema declares an absolute $id (e.g. https://ap2-protocol.org/schemas/...),
 // which JSON Schema treats as the base URI for resolving its own relative $refs.
@@ -23,24 +30,31 @@ const OUT_MANDATES_DIR = path.resolve(__dirname, '../src/generated/mandates');
 // file on disk. We mirror the schema tree into a temp dir with $id stripped so
 // $RefParser falls back to resolving $refs relative to the file on disk.
 async function stripIdsIntoTempDir(): Promise<string> {
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ap2-schemas-'));
-  await mkdir(path.join(tempDir, 'types'), { recursive: true });
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "ap2-schemas-"));
+  await mkdir(path.join(tempDir, "types"), { recursive: true });
 
-  const topFiles = (await readdir(SCHEMAS_DIR)).filter((f) => f.endsWith('.json'));
+  const topFiles = (await readdir(SCHEMAS_DIR)).filter((f) =>
+    f.endsWith(".json")
+  );
   for (const file of topFiles) {
     await copyWithoutId(path.join(SCHEMAS_DIR, file), path.join(tempDir, file));
   }
-  const typeFiles = (await readdir(TYPES_DIR)).filter((f) => f.endsWith('.json'));
+  const typeFiles = (await readdir(TYPES_DIR)).filter((f) =>
+    f.endsWith(".json")
+  );
   for (const file of typeFiles) {
-    await copyWithoutId(path.join(TYPES_DIR, file), path.join(tempDir, 'types', file));
+    await copyWithoutId(
+      path.join(TYPES_DIR, file),
+      path.join(tempDir, "types", file)
+    );
   }
   return tempDir;
 }
 
 async function copyWithoutId(src: string, dest: string): Promise<void> {
-  const schema = JSON.parse(await readFile(src, 'utf8'));
+  const schema = JSON.parse(await readFile(src, "utf8"));
   delete schema.$id;
-  await writeFile(dest, JSON.stringify(schema), 'utf8');
+  await writeFile(dest, JSON.stringify(schema), "utf8");
 }
 
 const HEADER = `// Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.\n\nimport { z } from 'zod';\n\n`;
@@ -56,10 +70,10 @@ const HEADER = `// Code generated from code/sdk/schemas/ap2 by scripts/generate.
 
 function toPascalCase(fileName: string): string {
   return fileName
-    .replace(/\.json$/, '')
+    .replace(/\.json$/, "")
     .split(/[_-]/)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join('');
+    .join("");
 }
 
 // json-schema-to-zod only reads each `oneOf` branch's `properties` const
@@ -77,22 +91,27 @@ function materializeSiblingOneOf(node: unknown): void {
     for (const item of node) materializeSiblingOneOf(item);
     return;
   }
-  if (node === null || typeof node !== 'object') return;
+  if (node === null || typeof node !== "object") return;
 
   const schema = node as Record<string, unknown>;
   if (
     Array.isArray(schema.oneOf) &&
     schema.properties &&
-    typeof schema.properties === 'object'
+    typeof schema.properties === "object"
   ) {
     const outerProperties = schema.properties as Record<string, unknown>;
     const outerRequired = Array.isArray(schema.required) ? schema.required : [];
     schema.oneOf = (schema.oneOf as Record<string, unknown>[]).map((branch) => {
-      const branchProperties = (branch.properties ?? {}) as Record<string, unknown>;
-      const branchRequired = Array.isArray(branch.required) ? branch.required : [];
+      const branchProperties = (branch.properties ?? {}) as Record<
+        string,
+        unknown
+      >;
+      const branchRequired = Array.isArray(branch.required)
+        ? branch.required
+        : [];
       return {
         ...branch,
-        type: 'object',
+        type: "object",
         properties: { ...outerProperties, ...branchProperties },
         required: [...new Set([...outerRequired, ...branchRequired])],
       };
@@ -107,46 +126,73 @@ function materializeSiblingOneOf(node: unknown): void {
 async function generateFile(
   schemaPath: string,
   outDir: string,
-  exportName: string,
+  exportName: string
 ): Promise<void> {
   // Dereference resolves both relative file $refs (e.g. "types/merchant.json")
   // and internal "#/$defs/..." refs into a single self-contained schema, so
   // each generated file has no cross-file runtime dependency.
-  const schema = (await $RefParser.dereference(schemaPath)) as Record<string, unknown>;
+  const schema = (await $RefParser.dereference(schemaPath)) as Record<
+    string,
+    unknown
+  >;
   // $id/$schema survive dereferencing but aren't meaningful to json-schema-to-zod.
   delete schema.$id;
   delete schema.$schema;
   materializeSiblingOneOf(schema);
 
-  const zodSource = jsonSchemaToZod(schema, { name: `${exportName}Schema`, module: 'esm' });
-  const body = zodSource.replace(/^import\s*\{\s*z\s*\}\s*from\s*['"]zod['"];?\n*/m, '');
+  const zodSource = jsonSchemaToZod(schema, {
+    name: `${exportName}Schema`,
+    module: "esm",
+  });
+  const body = zodSource.replace(
+    /^import\s*\{\s*z\s*\}\s*from\s*['"]zod['"];?\n*/m,
+    ""
+  );
 
   const contents = `${HEADER}${body}\nexport type ${exportName} = z.infer<typeof ${exportName}Schema>;\n`;
-  const formatted = await prettier.format(contents, { parser: 'typescript', singleQuote: true });
+  const prettierConfig = await prettier.resolveConfig(outDir);
+  const formatted = await prettier.format(contents, {
+    ...prettierConfig,
+    parser: "typescript",
+  });
   await mkdir(outDir, { recursive: true });
-  await writeFile(path.join(outDir, `${toKebabCase(exportName)}.ts`), formatted, 'utf8');
+  await writeFile(
+    path.join(outDir, `${toKebabCase(exportName)}.ts`),
+    formatted,
+    "utf8"
+  );
 }
 
 function toKebabCase(pascalCase: string): string {
-  return pascalCase.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+  return pascalCase.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
 }
 
 async function main(): Promise<void> {
   const tempDir = await stripIdsIntoTempDir();
   try {
-    const typeFiles = (await readdir(path.join(tempDir, 'types'))).filter((f) =>
-      f.endsWith('.json'),
+    const typeFiles = (await readdir(path.join(tempDir, "types"))).filter((f) =>
+      f.endsWith(".json")
     );
     for (const file of typeFiles) {
       const exportName = toPascalCase(file);
-      await generateFile(path.join(tempDir, 'types', file), OUT_TYPES_DIR, exportName);
+      await generateFile(
+        path.join(tempDir, "types", file),
+        OUT_TYPES_DIR,
+        exportName
+      );
       console.log(`generated types/${toKebabCase(exportName)}.ts`);
     }
 
-    const mandateFiles = (await readdir(tempDir)).filter((f) => f.endsWith('.json'));
+    const mandateFiles = (await readdir(tempDir)).filter((f) =>
+      f.endsWith(".json")
+    );
     for (const file of mandateFiles) {
       const exportName = toPascalCase(file);
-      await generateFile(path.join(tempDir, file), OUT_MANDATES_DIR, exportName);
+      await generateFile(
+        path.join(tempDir, file),
+        OUT_MANDATES_DIR,
+        exportName
+      );
       console.log(`generated mandates/${toKebabCase(exportName)}.ts`);
     }
   } finally {

--- a/code/sdk/typescript/scripts/generate.ts
+++ b/code/sdk/typescript/scripts/generate.ts
@@ -1,0 +1,160 @@
+// Generates Zod schemas + TypeScript types from the canonical AP2 JSON
+// Schemas in code/sdk/schemas/ap2/. Mirrors the role of
+// code/sdk/schemas/generate.py on the Python side, so the TS SDK can't drift
+// from the protocol's source of truth. Run via `npm run generate`.
+
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import $RefParser from '@apidevtools/json-schema-ref-parser';
+import { jsonSchemaToZod } from 'json-schema-to-zod';
+import prettier from 'prettier';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCHEMAS_DIR = path.resolve(__dirname, '../../schemas/ap2');
+const TYPES_DIR = path.join(SCHEMAS_DIR, 'types');
+const OUT_TYPES_DIR = path.resolve(__dirname, '../src/generated/types');
+const OUT_MANDATES_DIR = path.resolve(__dirname, '../src/generated/mandates');
+
+// Each schema declares an absolute $id (e.g. https://ap2-protocol.org/schemas/...),
+// which JSON Schema treats as the base URI for resolving its own relative $refs.
+// That sends "types/merchant.json" out to the network instead of the sibling
+// file on disk. We mirror the schema tree into a temp dir with $id stripped so
+// $RefParser falls back to resolving $refs relative to the file on disk.
+async function stripIdsIntoTempDir(): Promise<string> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'ap2-schemas-'));
+  await mkdir(path.join(tempDir, 'types'), { recursive: true });
+
+  const topFiles = (await readdir(SCHEMAS_DIR)).filter((f) => f.endsWith('.json'));
+  for (const file of topFiles) {
+    await copyWithoutId(path.join(SCHEMAS_DIR, file), path.join(tempDir, file));
+  }
+  const typeFiles = (await readdir(TYPES_DIR)).filter((f) => f.endsWith('.json'));
+  for (const file of typeFiles) {
+    await copyWithoutId(path.join(TYPES_DIR, file), path.join(tempDir, 'types', file));
+  }
+  return tempDir;
+}
+
+async function copyWithoutId(src: string, dest: string): Promise<void> {
+  const schema = JSON.parse(await readFile(src, 'utf8'));
+  delete schema.$id;
+  await writeFile(dest, JSON.stringify(schema), 'utf8');
+}
+
+const HEADER = `// Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.\n\nimport { z } from 'zod';\n\n`;
+
+// Known gap: json-schema-to-zod (v2.8.1) doesn't support the `contains`
+// keyword, so it's silently dropped. Two schemas use it to require "at least
+// one array element matching a specific alternative" (open_checkout_mandate's
+// `constraints` must contain a line_items entry; open_payment_mandate's
+// `constraints` must contain a payment_reference entry). The generated
+// validators accept arrays missing that element. See README "Known
+// limitations" — flagged rather than silently shipped, since a generic fix
+// requires deriving a runtime predicate from an arbitrary $ref'd subschema.
+
+function toPascalCase(fileName: string): string {
+  return fileName
+    .replace(/\.json$/, '')
+    .split(/[_-]/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+// json-schema-to-zod only reads each `oneOf` branch's `properties` const
+// checks and drops each branch's own `required` list when `oneOf` sits next
+// to `properties`/`required` on the same object (rather than each branch
+// being a fully self-contained alternative schema). AP2's receipt schemas
+// use exactly this "oneOf as a sibling constraint" idiom (e.g. a Success
+// receipt must additionally require psp_confirmation_id/network_confirmation_id).
+// We materialize each branch into a complete object schema — outer
+// properties/required merged with the branch's own — which the generator
+// already handles correctly for standalone-alternative-schema oneOfs
+// elsewhere (e.g. OpenPaymentMandate's constraints union).
+function materializeSiblingOneOf(node: unknown): void {
+  if (Array.isArray(node)) {
+    for (const item of node) materializeSiblingOneOf(item);
+    return;
+  }
+  if (node === null || typeof node !== 'object') return;
+
+  const schema = node as Record<string, unknown>;
+  if (
+    Array.isArray(schema.oneOf) &&
+    schema.properties &&
+    typeof schema.properties === 'object'
+  ) {
+    const outerProperties = schema.properties as Record<string, unknown>;
+    const outerRequired = Array.isArray(schema.required) ? schema.required : [];
+    schema.oneOf = (schema.oneOf as Record<string, unknown>[]).map((branch) => {
+      const branchProperties = (branch.properties ?? {}) as Record<string, unknown>;
+      const branchRequired = Array.isArray(branch.required) ? branch.required : [];
+      return {
+        ...branch,
+        type: 'object',
+        properties: { ...outerProperties, ...branchProperties },
+        required: [...new Set([...outerRequired, ...branchRequired])],
+      };
+    });
+    delete schema.properties;
+    delete schema.required;
+  }
+
+  for (const value of Object.values(schema)) materializeSiblingOneOf(value);
+}
+
+async function generateFile(
+  schemaPath: string,
+  outDir: string,
+  exportName: string,
+): Promise<void> {
+  // Dereference resolves both relative file $refs (e.g. "types/merchant.json")
+  // and internal "#/$defs/..." refs into a single self-contained schema, so
+  // each generated file has no cross-file runtime dependency.
+  const schema = (await $RefParser.dereference(schemaPath)) as Record<string, unknown>;
+  // $id/$schema survive dereferencing but aren't meaningful to json-schema-to-zod.
+  delete schema.$id;
+  delete schema.$schema;
+  materializeSiblingOneOf(schema);
+
+  const zodSource = jsonSchemaToZod(schema, { name: `${exportName}Schema`, module: 'esm' });
+  const body = zodSource.replace(/^import\s*\{\s*z\s*\}\s*from\s*['"]zod['"];?\n*/m, '');
+
+  const contents = `${HEADER}${body}\nexport type ${exportName} = z.infer<typeof ${exportName}Schema>;\n`;
+  const formatted = await prettier.format(contents, { parser: 'typescript', singleQuote: true });
+  await mkdir(outDir, { recursive: true });
+  await writeFile(path.join(outDir, `${toKebabCase(exportName)}.ts`), formatted, 'utf8');
+}
+
+function toKebabCase(pascalCase: string): string {
+  return pascalCase.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+async function main(): Promise<void> {
+  const tempDir = await stripIdsIntoTempDir();
+  try {
+    const typeFiles = (await readdir(path.join(tempDir, 'types'))).filter((f) =>
+      f.endsWith('.json'),
+    );
+    for (const file of typeFiles) {
+      const exportName = toPascalCase(file);
+      await generateFile(path.join(tempDir, 'types', file), OUT_TYPES_DIR, exportName);
+      console.log(`generated types/${toKebabCase(exportName)}.ts`);
+    }
+
+    const mandateFiles = (await readdir(tempDir)).filter((f) => f.endsWith('.json'));
+    for (const file of mandateFiles) {
+      const exportName = toPascalCase(file);
+      await generateFile(path.join(tempDir, file), OUT_MANDATES_DIR, exportName);
+      console.log(`generated mandates/${toKebabCase(exportName)}.ts`);
+    }
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/code/sdk/typescript/src/generated/mandates/checkout-mandate.ts
+++ b/code/sdk/typescript/src/generated/mandates/checkout-mandate.ts
@@ -1,0 +1,38 @@
+// Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
+
+import { z } from 'zod';
+
+export const CheckoutMandateSchema = z
+  .object({
+    vct: z
+      .literal('mandate.checkout.1')
+      .describe(
+        "Verifiable Credential Type claim as defined in SD-JWT. MUST be 'mandate.checkout'.",
+      )
+      .default('mandate.checkout.1'),
+    checkout_jwt: z
+      .string()
+      .describe(
+        'base64url-encoded serialized merchant-signed JWT of the Checkout payload.',
+      ),
+    checkout_hash: z
+      .string()
+      .describe(
+        'base64url-encoded hash of the checkout_jwt field value, uniquely identifying this checkout. If this checkout mandate is presented as an sd-jwt and the _sd_alg field is present then the hash algorithm used MUST match the _sd_alg field. Otherwise, sha-256 MUST be used.',
+      ),
+    iat: z
+      .number()
+      .int()
+      .describe('The creation timestamp as a Unix epoch.')
+      .optional(),
+    exp: z
+      .number()
+      .int()
+      .describe('The expiration timestamp as a Unix epoch.')
+      .optional(),
+  })
+  .describe(
+    'Agreement from a User or an Agent to authorize a particular Checkout action.',
+  );
+
+export type CheckoutMandate = z.infer<typeof CheckoutMandateSchema>;

--- a/code/sdk/typescript/src/generated/mandates/checkout-mandate.ts
+++ b/code/sdk/typescript/src/generated/mandates/checkout-mandate.ts
@@ -1,38 +1,38 @@
 // Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
 
-import { z } from 'zod';
+import { z } from "zod";
 
 export const CheckoutMandateSchema = z
   .object({
     vct: z
-      .literal('mandate.checkout.1')
+      .literal("mandate.checkout.1")
       .describe(
-        "Verifiable Credential Type claim as defined in SD-JWT. MUST be 'mandate.checkout'.",
+        "Verifiable Credential Type claim as defined in SD-JWT. MUST be 'mandate.checkout'."
       )
-      .default('mandate.checkout.1'),
+      .default("mandate.checkout.1"),
     checkout_jwt: z
       .string()
       .describe(
-        'base64url-encoded serialized merchant-signed JWT of the Checkout payload.',
+        "base64url-encoded serialized merchant-signed JWT of the Checkout payload."
       ),
     checkout_hash: z
       .string()
       .describe(
-        'base64url-encoded hash of the checkout_jwt field value, uniquely identifying this checkout. If this checkout mandate is presented as an sd-jwt and the _sd_alg field is present then the hash algorithm used MUST match the _sd_alg field. Otherwise, sha-256 MUST be used.',
+        "base64url-encoded hash of the checkout_jwt field value, uniquely identifying this checkout. If this checkout mandate is presented as an sd-jwt and the _sd_alg field is present then the hash algorithm used MUST match the _sd_alg field. Otherwise, sha-256 MUST be used."
       ),
     iat: z
       .number()
       .int()
-      .describe('The creation timestamp as a Unix epoch.')
+      .describe("The creation timestamp as a Unix epoch.")
       .optional(),
     exp: z
       .number()
       .int()
-      .describe('The expiration timestamp as a Unix epoch.')
+      .describe("The expiration timestamp as a Unix epoch.")
       .optional(),
   })
   .describe(
-    'Agreement from a User or an Agent to authorize a particular Checkout action.',
+    "Agreement from a User or an Agent to authorize a particular Checkout action."
   );
 
 export type CheckoutMandate = z.infer<typeof CheckoutMandateSchema>;

--- a/code/sdk/typescript/src/generated/mandates/checkout-receipt.ts
+++ b/code/sdk/typescript/src/generated/mandates/checkout-receipt.ts
@@ -1,0 +1,110 @@
+// Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
+
+import { z } from 'zod';
+
+export const CheckoutReceiptSchema = z
+  .record(z.string(), z.any())
+  .and(
+    z.any().superRefine((x, ctx) => {
+      const schemas = [
+        z.object({
+          status: z.literal('Success'),
+          iss: z.string().describe('The issuer of the receipt.'),
+          iat: z
+            .number()
+            .int()
+            .describe('The creation timestamp as a Unix epoch.'),
+          reference: z
+            .string()
+            .describe(
+              'The hash of the closed Mandate that this receipt is binding to.',
+            ),
+          error: z
+            .string()
+            .describe(
+              'A unique error code. Present if and only if status is Error.',
+            )
+            .optional(),
+          error_description: z
+            .string()
+            .describe(
+              'A human-readable error description. Present if and only if status is Error.',
+            )
+            .optional(),
+          order_id: z
+            .string()
+            .describe(
+              'A reference to the order for the checkout. Present if and only if status is Success.',
+            ),
+        }),
+        z.object({
+          status: z.literal('Error'),
+          iss: z.string().describe('The issuer of the receipt.'),
+          iat: z
+            .number()
+            .int()
+            .describe('The creation timestamp as a Unix epoch.'),
+          reference: z
+            .string()
+            .describe(
+              'The hash of the closed Mandate that this receipt is binding to.',
+            ),
+          error: z
+            .string()
+            .describe(
+              'A unique error code. Present if and only if status is Error.',
+            ),
+          error_description: z
+            .string()
+            .describe(
+              'A human-readable error description. Present if and only if status is Error.',
+            ),
+          order_id: z
+            .string()
+            .describe(
+              'A reference to the order for the checkout. Present if and only if status is Success.',
+            )
+            .optional(),
+        }),
+      ];
+      const { errors, failed } = schemas.reduce<{
+        errors: z.core.$ZodIssue[];
+        failed: number;
+      }>(
+        ({ errors, failed }, schema) =>
+          ((result) =>
+            result.error
+              ? {
+                  errors: [...errors, ...result.error.issues],
+                  failed: failed + 1,
+                }
+              : { errors, failed })(schema.safeParse(x)),
+        { errors: [], failed: 0 },
+      );
+      const passed = schemas.length - failed;
+      if (passed !== 1) {
+        ctx.addIssue(
+          errors.length
+            ? {
+                path: [],
+                code: 'invalid_union',
+                errors: [errors],
+                message:
+                  'Invalid input: Should pass single schema. Passed ' + passed,
+              }
+            : {
+                path: [],
+                code: 'custom',
+                errors: [errors],
+                message:
+                  'Invalid input: Should pass single schema. Passed ' + passed,
+              },
+        );
+      }
+    }),
+  )
+  .describe(
+    'Receipt that supplies information about the final state of a checkout.',
+  );
+
+export type CheckoutReceipt = z.infer<typeof CheckoutReceiptSchema>;

--- a/code/sdk/typescript/src/generated/mandates/checkout-receipt.ts
+++ b/code/sdk/typescript/src/generated/mandates/checkout-receipt.ts
@@ -1,6 +1,6 @@
 // Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
 
-import { z } from 'zod';
+import { z } from "zod";
 
 export const CheckoutReceiptSchema = z
   .record(z.string(), z.any())
@@ -8,61 +8,61 @@ export const CheckoutReceiptSchema = z
     z.any().superRefine((x, ctx) => {
       const schemas = [
         z.object({
-          status: z.literal('Success'),
-          iss: z.string().describe('The issuer of the receipt.'),
+          status: z.literal("Success"),
+          iss: z.string().describe("The issuer of the receipt."),
           iat: z
             .number()
             .int()
-            .describe('The creation timestamp as a Unix epoch.'),
+            .describe("The creation timestamp as a Unix epoch."),
           reference: z
             .string()
             .describe(
-              'The hash of the closed Mandate that this receipt is binding to.',
+              "The hash of the closed Mandate that this receipt is binding to."
             ),
           error: z
             .string()
             .describe(
-              'A unique error code. Present if and only if status is Error.',
+              "A unique error code. Present if and only if status is Error."
             )
             .optional(),
           error_description: z
             .string()
             .describe(
-              'A human-readable error description. Present if and only if status is Error.',
+              "A human-readable error description. Present if and only if status is Error."
             )
             .optional(),
           order_id: z
             .string()
             .describe(
-              'A reference to the order for the checkout. Present if and only if status is Success.',
+              "A reference to the order for the checkout. Present if and only if status is Success."
             ),
         }),
         z.object({
-          status: z.literal('Error'),
-          iss: z.string().describe('The issuer of the receipt.'),
+          status: z.literal("Error"),
+          iss: z.string().describe("The issuer of the receipt."),
           iat: z
             .number()
             .int()
-            .describe('The creation timestamp as a Unix epoch.'),
+            .describe("The creation timestamp as a Unix epoch."),
           reference: z
             .string()
             .describe(
-              'The hash of the closed Mandate that this receipt is binding to.',
+              "The hash of the closed Mandate that this receipt is binding to."
             ),
           error: z
             .string()
             .describe(
-              'A unique error code. Present if and only if status is Error.',
+              "A unique error code. Present if and only if status is Error."
             ),
           error_description: z
             .string()
             .describe(
-              'A human-readable error description. Present if and only if status is Error.',
+              "A human-readable error description. Present if and only if status is Error."
             ),
           order_id: z
             .string()
             .describe(
-              'A reference to the order for the checkout. Present if and only if status is Success.',
+              "A reference to the order for the checkout. Present if and only if status is Success."
             )
             .optional(),
         }),
@@ -79,7 +79,7 @@ export const CheckoutReceiptSchema = z
                   failed: failed + 1,
                 }
               : { errors, failed })(schema.safeParse(x)),
-        { errors: [], failed: 0 },
+        { errors: [], failed: 0 }
       );
       const passed = schemas.length - failed;
       if (passed !== 1) {
@@ -87,24 +87,24 @@ export const CheckoutReceiptSchema = z
           errors.length
             ? {
                 path: [],
-                code: 'invalid_union',
+                code: "invalid_union",
                 errors: [errors],
                 message:
-                  'Invalid input: Should pass single schema. Passed ' + passed,
+                  "Invalid input: Should pass single schema. Passed " + passed,
               }
             : {
                 path: [],
-                code: 'custom',
+                code: "custom",
                 errors: [errors],
                 message:
-                  'Invalid input: Should pass single schema. Passed ' + passed,
-              },
+                  "Invalid input: Should pass single schema. Passed " + passed,
+              }
         );
       }
-    }),
+    })
   )
   .describe(
-    'Receipt that supplies information about the final state of a checkout.',
+    "Receipt that supplies information about the final state of a checkout."
   );
 
 export type CheckoutReceipt = z.infer<typeof CheckoutReceiptSchema>;

--- a/code/sdk/typescript/src/generated/mandates/open-checkout-mandate.ts
+++ b/code/sdk/typescript/src/generated/mandates/open-checkout-mandate.ts
@@ -1,59 +1,59 @@
 // Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
 
-import { z } from 'zod';
+import { z } from "zod";
 
 export const OpenCheckoutMandateSchema = z
   .object({
     vct: z
-      .literal('mandate.checkout.open.1')
+      .literal("mandate.checkout.open.1")
       .describe(
-        "Verifiable Credential Type claim as defined in SD-JWT. MUST be 'mandate.checkout.open'.",
+        "Verifiable Credential Type claim as defined in SD-JWT. MUST be 'mandate.checkout.open'."
       )
-      .default('mandate.checkout.open.1'),
+      .default("mandate.checkout.open.1"),
     constraints: z
       .array(
         z.union([
           z
             .object({
               type: z
-                .literal('checkout.allowed_merchants')
-                .describe('Constraint type identifier.')
-                .default('checkout.allowed_merchants'),
+                .literal("checkout.allowed_merchants")
+                .describe("Constraint type identifier.")
+                .default("checkout.allowed_merchants"),
               allowed: z
                 .array(
                   z
                     .object({
                       id: z
                         .string()
-                        .describe('Unique identifier for the merchant.'),
+                        .describe("Unique identifier for the merchant."),
                       name: z
                         .string()
-                        .describe('Human-readable name of the merchant.'),
+                        .describe("Human-readable name of the merchant."),
                       website: z
                         .string()
-                        .describe('Website belonging to the merchant.')
+                        .describe("Website belonging to the merchant.")
                         .optional(),
                     })
-                    .describe('Schema defining a Mechant object'),
+                    .describe("Schema defining a Mechant object")
                 )
-                .describe('Array of allowed Merchant objects.'),
+                .describe("Array of allowed Merchant objects."),
             })
             .describe(
-              'Defines the set of possible merchants for this Checkout Mandate.',
+              "Defines the set of possible merchants for this Checkout Mandate."
             ),
           z
             .object({
               type: z
-                .literal('checkout.line_items')
-                .describe('Constraint type identifier.')
-                .default('checkout.line_items'),
+                .literal("checkout.line_items")
+                .describe("Constraint type identifier.")
+                .default("checkout.line_items"),
               items: z
                 .array(
                   z
                     .object({
                       id: z
                         .string()
-                        .describe('Identifier for the line item requirement.'),
+                        .describe("Identifier for the line item requirement."),
                       acceptable_items: z
                         .array(
                           z
@@ -61,56 +61,56 @@ export const OpenCheckoutMandateSchema = z
                               id: z
                                 .string()
                                 .describe(
-                                  'Unique identifier for the line item. Will often be the SKU.',
+                                  "Unique identifier for the line item. Will often be the SKU."
                                 ),
-                              title: z.string().describe('Title of the item.'),
+                              title: z.string().describe("Title of the item."),
                             })
                             .describe(
-                              'Defines an item that may be present in the Checkout Mandate.',
-                            ),
+                              "Defines an item that may be present in the Checkout Mandate."
+                            )
                         )
                         .describe(
-                          'Defines a set of line items that are acceptable for this line item requirement. One and only one must be present in the Checkout Mandate.',
+                          "Defines a set of line items that are acceptable for this line item requirement. One and only one must be present in the Checkout Mandate."
                         ),
                       quantity: z
                         .number()
                         .int()
                         .gt(0)
-                        .describe('Required quantity of matching items.'),
+                        .describe("Required quantity of matching items."),
                     })
                     .describe(
-                      'Defines a line item that must be present in the Checkout Mandate.',
-                    ),
+                      "Defines a line item that must be present in the Checkout Mandate."
+                    )
                 )
                 .min(1)
-                .describe('Array of line item requirements.'),
+                .describe("Array of line item requirements."),
             })
             .describe(
-              'Defines the sets of line items that are to be present in the Checkout Mandate.',
+              "Defines the sets of line items that are to be present in the Checkout Mandate."
             ),
-        ]),
+        ])
       )
       .describe(
-        'Array of constraints that the future checkout action must abide by.',
+        "Array of constraints that the future checkout action must abide by."
       ),
     cnf: z
       .record(z.string(), z.any())
       .describe(
-        'Confirmation claim defined in RFC 7800 section 3.1. Used for key binding.',
+        "Confirmation claim defined in RFC 7800 section 3.1. Used for key binding."
       ),
     iat: z
       .number()
       .int()
-      .describe('The creation timestamp as a Unix epoch.')
+      .describe("The creation timestamp as a Unix epoch.")
       .optional(),
     exp: z
       .number()
       .int()
-      .describe('The expiration timestamp as a Unix epoch.')
+      .describe("The expiration timestamp as a Unix epoch.")
       .optional(),
   })
   .describe(
-    'Agreement between a user and an agent (or chain of agents) to authorize future checkout actions.',
+    "Agreement between a user and an agent (or chain of agents) to authorize future checkout actions."
   );
 
 export type OpenCheckoutMandate = z.infer<typeof OpenCheckoutMandateSchema>;

--- a/code/sdk/typescript/src/generated/mandates/open-checkout-mandate.ts
+++ b/code/sdk/typescript/src/generated/mandates/open-checkout-mandate.ts
@@ -1,0 +1,116 @@
+// Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
+
+import { z } from 'zod';
+
+export const OpenCheckoutMandateSchema = z
+  .object({
+    vct: z
+      .literal('mandate.checkout.open.1')
+      .describe(
+        "Verifiable Credential Type claim as defined in SD-JWT. MUST be 'mandate.checkout.open'.",
+      )
+      .default('mandate.checkout.open.1'),
+    constraints: z
+      .array(
+        z.union([
+          z
+            .object({
+              type: z
+                .literal('checkout.allowed_merchants')
+                .describe('Constraint type identifier.')
+                .default('checkout.allowed_merchants'),
+              allowed: z
+                .array(
+                  z
+                    .object({
+                      id: z
+                        .string()
+                        .describe('Unique identifier for the merchant.'),
+                      name: z
+                        .string()
+                        .describe('Human-readable name of the merchant.'),
+                      website: z
+                        .string()
+                        .describe('Website belonging to the merchant.')
+                        .optional(),
+                    })
+                    .describe('Schema defining a Mechant object'),
+                )
+                .describe('Array of allowed Merchant objects.'),
+            })
+            .describe(
+              'Defines the set of possible merchants for this Checkout Mandate.',
+            ),
+          z
+            .object({
+              type: z
+                .literal('checkout.line_items')
+                .describe('Constraint type identifier.')
+                .default('checkout.line_items'),
+              items: z
+                .array(
+                  z
+                    .object({
+                      id: z
+                        .string()
+                        .describe('Identifier for the line item requirement.'),
+                      acceptable_items: z
+                        .array(
+                          z
+                            .object({
+                              id: z
+                                .string()
+                                .describe(
+                                  'Unique identifier for the line item. Will often be the SKU.',
+                                ),
+                              title: z.string().describe('Title of the item.'),
+                            })
+                            .describe(
+                              'Defines an item that may be present in the Checkout Mandate.',
+                            ),
+                        )
+                        .describe(
+                          'Defines a set of line items that are acceptable for this line item requirement. One and only one must be present in the Checkout Mandate.',
+                        ),
+                      quantity: z
+                        .number()
+                        .int()
+                        .gt(0)
+                        .describe('Required quantity of matching items.'),
+                    })
+                    .describe(
+                      'Defines a line item that must be present in the Checkout Mandate.',
+                    ),
+                )
+                .min(1)
+                .describe('Array of line item requirements.'),
+            })
+            .describe(
+              'Defines the sets of line items that are to be present in the Checkout Mandate.',
+            ),
+        ]),
+      )
+      .describe(
+        'Array of constraints that the future checkout action must abide by.',
+      ),
+    cnf: z
+      .record(z.string(), z.any())
+      .describe(
+        'Confirmation claim defined in RFC 7800 section 3.1. Used for key binding.',
+      ),
+    iat: z
+      .number()
+      .int()
+      .describe('The creation timestamp as a Unix epoch.')
+      .optional(),
+    exp: z
+      .number()
+      .int()
+      .describe('The expiration timestamp as a Unix epoch.')
+      .optional(),
+  })
+  .describe(
+    'Agreement between a user and an agent (or chain of agents) to authorize future checkout actions.',
+  );
+
+export type OpenCheckoutMandate = z.infer<typeof OpenCheckoutMandateSchema>;

--- a/code/sdk/typescript/src/generated/mandates/open-payment-mandate.ts
+++ b/code/sdk/typescript/src/generated/mandates/open-payment-mandate.ts
@@ -1,0 +1,331 @@
+// Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
+
+import { z } from 'zod';
+
+export const OpenPaymentMandateSchema = z
+  .object({
+    vct: z
+      .literal('mandate.payment.open.1')
+      .describe(
+        "Verifiable Credential Type claim as defined in SD-JWT. MUST be 'mandate.payment.open'.",
+      )
+      .default('mandate.payment.open.1'),
+    constraints: z
+      .array(
+        z.any().superRefine((x, ctx) => {
+          const schemas = [
+            z
+              .object({
+                type: z
+                  .literal('payment.agent_recurrence')
+                  .describe('Constraint type identifier.')
+                  .default('payment.agent_recurrence'),
+                frequency: z
+                  .enum([
+                    'ON_DEMAND',
+                    'DAILY',
+                    'WEEKLY',
+                    'BIWEEKLY',
+                    'MONTHLY',
+                    'QUARTERLY',
+                    'ANNUALLY',
+                  ])
+                  .describe('Frequency of allowed recurrences.'),
+                max_occurrences: z
+                  .number()
+                  .int()
+                  .describe('Maximum number of allowed occurrences.')
+                  .optional(),
+              })
+              .describe(
+                'Provides conditions for the agent to reuse this Payment Mandate multiple times.',
+              ),
+            z
+              .object({
+                type: z
+                  .literal('payment.allowed_payees')
+                  .describe('Constraint type identifier.')
+                  .default('payment.allowed_payees'),
+                allowed: z
+                  .array(
+                    z
+                      .object({
+                        id: z
+                          .string()
+                          .describe('Unique identifier for the merchant.'),
+                        name: z
+                          .string()
+                          .describe('Human-readable name of the merchant.'),
+                        website: z
+                          .string()
+                          .describe('Website belonging to the merchant.')
+                          .optional(),
+                      })
+                      .describe('Schema defining a Mechant object'),
+                  )
+                  .describe('Array of allowed Merchant objects.'),
+              })
+              .describe('Defines the set of possible payees.'),
+            z
+              .object({
+                type: z
+                  .literal('payment.allowed_payment_instruments')
+                  .describe('Constraint type identifier.')
+                  .default('payment.allowed_payment_instruments'),
+                allowed: z
+                  .array(
+                    z
+                      .object({
+                        id: z
+                          .string()
+                          .describe('unique identifier for this instrument'),
+                        type: z
+                          .string()
+                          .describe(
+                            'unique string identifying this category of instrument',
+                          ),
+                        description: z
+                          .string()
+                          .describe(
+                            'Description of the instrument to be displayed to the user for informational purposes',
+                          )
+                          .optional(),
+                      })
+                      .describe('Instrument used for payment.'),
+                  )
+                  .describe('Array of allowed payment instruments.'),
+              })
+              .describe(
+                'Defines the set of possible payment instruments for this Payment Mandate.',
+              ),
+            z
+              .object({
+                type: z
+                  .literal('payment.allowed_pisps')
+                  .describe('Constraint type identifier.')
+                  .default('payment.allowed_pisps'),
+                allowed: z
+                  .array(
+                    z
+                      .object({
+                        legal_name: z
+                          .string()
+                          .describe('Legal name of the PISP.'),
+                        brand_name: z
+                          .string()
+                          .describe('Brand name of the PISP.'),
+                        domain_name: z
+                          .string()
+                          .describe(
+                            'Domain name of the PISP as secured by the [eIDAS] QWAC certificate of the TPP.',
+                          ),
+                      })
+                      .describe(
+                        'Schema defining a Payment Initiation Service Provider (PISP) object',
+                      ),
+                  )
+                  .describe('Array of allowed PISPs.'),
+              })
+              .describe(
+                'Defines the set of Payment Initiation Service Providers (PISPs) authorized to facilitate the transaction.',
+              ),
+            z
+              .object({
+                type: z
+                  .literal('payment.amount_range')
+                  .describe('Constraint type identifier.')
+                  .default('payment.amount_range'),
+                currency: z.string().describe('ISO4217 Alpha-3 currency code.'),
+                max: z
+                  .number()
+                  .int()
+                  .describe(
+                    'Maximum allowed amount in minor (cents) unit of currency.',
+                  ),
+                min: z
+                  .number()
+                  .int()
+                  .describe(
+                    'Minimal amount in minor (cents) unit of currency. If absent, there is no minimum.',
+                  )
+                  .optional(),
+              })
+              .describe('Defines the valid range for the payment amount'),
+            z
+              .object({
+                type: z
+                  .literal('payment.budget')
+                  .describe('Constraint type identifier.')
+                  .default('payment.budget'),
+                max: z.number().describe('Maximum amount for the budget.'),
+                currency: z
+                  .string()
+                  .describe(
+                    'ISO4217 Alpha-3 defining the currency of the amount.',
+                  ),
+              })
+              .describe(
+                'Defines the maximum total amount that can be spent when using the payment.agent_recurrence constraint.',
+              ),
+            z
+              .object({
+                type: z
+                  .literal('payment.execution_date')
+                  .describe('Constraint type identifier.')
+                  .default('payment.execution_date'),
+                not_before: z
+                  .string()
+                  .describe('Earliest valid execution date.')
+                  .optional(),
+                not_after: z
+                  .string()
+                  .describe('Latest valid execution date.')
+                  .optional(),
+              })
+              .describe(
+                'Defines the valid time window for the payment execution.',
+              ),
+            z
+              .object({
+                type: z
+                  .literal('payment.reference')
+                  .describe('Constraint type identifier.')
+                  .default('payment.reference'),
+                conditional_transaction_id: z
+                  .string()
+                  .describe('Digest of the associated Open Checkout Mandate.'),
+              })
+              .describe(
+                'Constrains the payment to a specific checkout reference.',
+              ),
+          ];
+          const { errors, failed } = schemas.reduce<{
+            errors: z.core.$ZodIssue[];
+            failed: number;
+          }>(
+            ({ errors, failed }, schema) =>
+              ((result) =>
+                result.error
+                  ? {
+                      errors: [...errors, ...result.error.issues],
+                      failed: failed + 1,
+                    }
+                  : { errors, failed })(schema.safeParse(x)),
+            { errors: [], failed: 0 },
+          );
+          const passed = schemas.length - failed;
+          if (passed !== 1) {
+            ctx.addIssue(
+              errors.length
+                ? {
+                    path: [],
+                    code: 'invalid_union',
+                    errors: [errors],
+                    message:
+                      'Invalid input: Should pass single schema. Passed ' +
+                      passed,
+                  }
+                : {
+                    path: [],
+                    code: 'custom',
+                    errors: [errors],
+                    message:
+                      'Invalid input: Should pass single schema. Passed ' +
+                      passed,
+                  },
+            );
+          }
+        }),
+      )
+      .describe(
+        'Array of constraints that the future checkout action must abide by.',
+      ),
+    cnf: z
+      .record(z.string(), z.any())
+      .describe(
+        'Confirmation claim as defined in RFC 7800 section 3.1. Used for key binding.',
+      ),
+    payee: z
+      .object({
+        id: z.string().describe('Unique identifier for the merchant.'),
+        name: z.string().describe('Human-readable name of the merchant.'),
+        website: z
+          .string()
+          .describe('Website belonging to the merchant.')
+          .optional(),
+      })
+      .describe('Schema defining a Mechant object')
+      .optional(),
+    payment_amount: z
+      .object({
+        amount: z
+          .number()
+          .int()
+          .describe('Amount in minor units, according to the ISO-4217 spec.'),
+        currency: z
+          .string()
+          .describe(
+            'ISO-4217 3-letter alphabetic currency code of the payment.',
+          ),
+      })
+      .describe(
+        'Transaction amount object containing currency (ISO 4217 code, e.g., "USD") and amount (integer minor units per ISO 4217, e.g., 27999 = $279.99). Pre-set by the user at time of mandate creation.',
+      )
+      .optional(),
+    payment_instrument: z
+      .object({
+        id: z.string().describe('unique identifier for this instrument'),
+        type: z
+          .string()
+          .describe('unique string identifying this category of instrument'),
+        description: z
+          .string()
+          .describe(
+            'Description of the instrument to be displayed to the user for informational purposes',
+          )
+          .optional(),
+      })
+      .describe('Instrument used for payment.')
+      .optional(),
+    pisp: z
+      .object({
+        legal_name: z.string().describe('Legal name of the PISP.'),
+        brand_name: z.string().describe('Brand name of the PISP.'),
+        domain_name: z
+          .string()
+          .describe(
+            'Domain name of the PISP as secured by the [eIDAS] QWAC certificate of the TPP.',
+          ),
+      })
+      .describe(
+        'Schema defining a Payment Initiation Service Provider (PISP) object',
+      )
+      .optional(),
+    execution_date: z
+      .string()
+      .describe(
+        'ISO8601 date of execution of payment. When absent indicates immediate execution.',
+      )
+      .optional(),
+    risk_data: z
+      .record(z.string(), z.any())
+      .describe(
+        'An map of relevant risk signals collected by the trusted surface at time of mandate creation.',
+      )
+      .optional(),
+    iat: z
+      .number()
+      .int()
+      .describe('The creation timestamp as a Unix epoch.')
+      .optional(),
+    exp: z
+      .number()
+      .int()
+      .describe('The expiration timestamp as a Unix epoch.')
+      .optional(),
+  })
+  .describe(
+    'Agreement between a user and an agent (or chain of agents) to authorize future payment actions.',
+  );
+
+export type OpenPaymentMandate = z.infer<typeof OpenPaymentMandateSchema>;

--- a/code/sdk/typescript/src/generated/mandates/open-payment-mandate.ts
+++ b/code/sdk/typescript/src/generated/mandates/open-payment-mandate.ts
@@ -1,15 +1,15 @@
 // Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
 
-import { z } from 'zod';
+import { z } from "zod";
 
 export const OpenPaymentMandateSchema = z
   .object({
     vct: z
-      .literal('mandate.payment.open.1')
+      .literal("mandate.payment.open.1")
       .describe(
-        "Verifiable Credential Type claim as defined in SD-JWT. MUST be 'mandate.payment.open'.",
+        "Verifiable Credential Type claim as defined in SD-JWT. MUST be 'mandate.payment.open'."
       )
-      .default('mandate.payment.open.1'),
+      .default("mandate.payment.open.1"),
     constraints: z
       .array(
         z.any().superRefine((x, ctx) => {
@@ -17,186 +17,186 @@ export const OpenPaymentMandateSchema = z
             z
               .object({
                 type: z
-                  .literal('payment.agent_recurrence')
-                  .describe('Constraint type identifier.')
-                  .default('payment.agent_recurrence'),
+                  .literal("payment.agent_recurrence")
+                  .describe("Constraint type identifier.")
+                  .default("payment.agent_recurrence"),
                 frequency: z
                   .enum([
-                    'ON_DEMAND',
-                    'DAILY',
-                    'WEEKLY',
-                    'BIWEEKLY',
-                    'MONTHLY',
-                    'QUARTERLY',
-                    'ANNUALLY',
+                    "ON_DEMAND",
+                    "DAILY",
+                    "WEEKLY",
+                    "BIWEEKLY",
+                    "MONTHLY",
+                    "QUARTERLY",
+                    "ANNUALLY",
                   ])
-                  .describe('Frequency of allowed recurrences.'),
+                  .describe("Frequency of allowed recurrences."),
                 max_occurrences: z
                   .number()
                   .int()
-                  .describe('Maximum number of allowed occurrences.')
+                  .describe("Maximum number of allowed occurrences.")
                   .optional(),
               })
               .describe(
-                'Provides conditions for the agent to reuse this Payment Mandate multiple times.',
+                "Provides conditions for the agent to reuse this Payment Mandate multiple times."
               ),
             z
               .object({
                 type: z
-                  .literal('payment.allowed_payees')
-                  .describe('Constraint type identifier.')
-                  .default('payment.allowed_payees'),
+                  .literal("payment.allowed_payees")
+                  .describe("Constraint type identifier.")
+                  .default("payment.allowed_payees"),
                 allowed: z
                   .array(
                     z
                       .object({
                         id: z
                           .string()
-                          .describe('Unique identifier for the merchant.'),
+                          .describe("Unique identifier for the merchant."),
                         name: z
                           .string()
-                          .describe('Human-readable name of the merchant.'),
+                          .describe("Human-readable name of the merchant."),
                         website: z
                           .string()
-                          .describe('Website belonging to the merchant.')
+                          .describe("Website belonging to the merchant.")
                           .optional(),
                       })
-                      .describe('Schema defining a Mechant object'),
+                      .describe("Schema defining a Mechant object")
                   )
-                  .describe('Array of allowed Merchant objects.'),
+                  .describe("Array of allowed Merchant objects."),
               })
-              .describe('Defines the set of possible payees.'),
+              .describe("Defines the set of possible payees."),
             z
               .object({
                 type: z
-                  .literal('payment.allowed_payment_instruments')
-                  .describe('Constraint type identifier.')
-                  .default('payment.allowed_payment_instruments'),
+                  .literal("payment.allowed_payment_instruments")
+                  .describe("Constraint type identifier.")
+                  .default("payment.allowed_payment_instruments"),
                 allowed: z
                   .array(
                     z
                       .object({
                         id: z
                           .string()
-                          .describe('unique identifier for this instrument'),
+                          .describe("unique identifier for this instrument"),
                         type: z
                           .string()
                           .describe(
-                            'unique string identifying this category of instrument',
+                            "unique string identifying this category of instrument"
                           ),
                         description: z
                           .string()
                           .describe(
-                            'Description of the instrument to be displayed to the user for informational purposes',
+                            "Description of the instrument to be displayed to the user for informational purposes"
                           )
                           .optional(),
                       })
-                      .describe('Instrument used for payment.'),
+                      .describe("Instrument used for payment.")
                   )
-                  .describe('Array of allowed payment instruments.'),
+                  .describe("Array of allowed payment instruments."),
               })
               .describe(
-                'Defines the set of possible payment instruments for this Payment Mandate.',
+                "Defines the set of possible payment instruments for this Payment Mandate."
               ),
             z
               .object({
                 type: z
-                  .literal('payment.allowed_pisps')
-                  .describe('Constraint type identifier.')
-                  .default('payment.allowed_pisps'),
+                  .literal("payment.allowed_pisps")
+                  .describe("Constraint type identifier.")
+                  .default("payment.allowed_pisps"),
                 allowed: z
                   .array(
                     z
                       .object({
                         legal_name: z
                           .string()
-                          .describe('Legal name of the PISP.'),
+                          .describe("Legal name of the PISP."),
                         brand_name: z
                           .string()
-                          .describe('Brand name of the PISP.'),
+                          .describe("Brand name of the PISP."),
                         domain_name: z
                           .string()
                           .describe(
-                            'Domain name of the PISP as secured by the [eIDAS] QWAC certificate of the TPP.',
+                            "Domain name of the PISP as secured by the [eIDAS] QWAC certificate of the TPP."
                           ),
                       })
                       .describe(
-                        'Schema defining a Payment Initiation Service Provider (PISP) object',
-                      ),
+                        "Schema defining a Payment Initiation Service Provider (PISP) object"
+                      )
                   )
-                  .describe('Array of allowed PISPs.'),
+                  .describe("Array of allowed PISPs."),
               })
               .describe(
-                'Defines the set of Payment Initiation Service Providers (PISPs) authorized to facilitate the transaction.',
+                "Defines the set of Payment Initiation Service Providers (PISPs) authorized to facilitate the transaction."
               ),
             z
               .object({
                 type: z
-                  .literal('payment.amount_range')
-                  .describe('Constraint type identifier.')
-                  .default('payment.amount_range'),
-                currency: z.string().describe('ISO4217 Alpha-3 currency code.'),
+                  .literal("payment.amount_range")
+                  .describe("Constraint type identifier.")
+                  .default("payment.amount_range"),
+                currency: z.string().describe("ISO4217 Alpha-3 currency code."),
                 max: z
                   .number()
                   .int()
                   .describe(
-                    'Maximum allowed amount in minor (cents) unit of currency.',
+                    "Maximum allowed amount in minor (cents) unit of currency."
                   ),
                 min: z
                   .number()
                   .int()
                   .describe(
-                    'Minimal amount in minor (cents) unit of currency. If absent, there is no minimum.',
+                    "Minimal amount in minor (cents) unit of currency. If absent, there is no minimum."
                   )
                   .optional(),
               })
-              .describe('Defines the valid range for the payment amount'),
+              .describe("Defines the valid range for the payment amount"),
             z
               .object({
                 type: z
-                  .literal('payment.budget')
-                  .describe('Constraint type identifier.')
-                  .default('payment.budget'),
-                max: z.number().describe('Maximum amount for the budget.'),
+                  .literal("payment.budget")
+                  .describe("Constraint type identifier.")
+                  .default("payment.budget"),
+                max: z.number().describe("Maximum amount for the budget."),
                 currency: z
                   .string()
                   .describe(
-                    'ISO4217 Alpha-3 defining the currency of the amount.',
+                    "ISO4217 Alpha-3 defining the currency of the amount."
                   ),
               })
               .describe(
-                'Defines the maximum total amount that can be spent when using the payment.agent_recurrence constraint.',
+                "Defines the maximum total amount that can be spent when using the payment.agent_recurrence constraint."
               ),
             z
               .object({
                 type: z
-                  .literal('payment.execution_date')
-                  .describe('Constraint type identifier.')
-                  .default('payment.execution_date'),
+                  .literal("payment.execution_date")
+                  .describe("Constraint type identifier.")
+                  .default("payment.execution_date"),
                 not_before: z
                   .string()
-                  .describe('Earliest valid execution date.')
+                  .describe("Earliest valid execution date.")
                   .optional(),
                 not_after: z
                   .string()
-                  .describe('Latest valid execution date.')
+                  .describe("Latest valid execution date.")
                   .optional(),
               })
               .describe(
-                'Defines the valid time window for the payment execution.',
+                "Defines the valid time window for the payment execution."
               ),
             z
               .object({
                 type: z
-                  .literal('payment.reference')
-                  .describe('Constraint type identifier.')
-                  .default('payment.reference'),
+                  .literal("payment.reference")
+                  .describe("Constraint type identifier.")
+                  .default("payment.reference"),
                 conditional_transaction_id: z
                   .string()
-                  .describe('Digest of the associated Open Checkout Mandate.'),
+                  .describe("Digest of the associated Open Checkout Mandate."),
               })
               .describe(
-                'Constrains the payment to a specific checkout reference.',
+                "Constrains the payment to a specific checkout reference."
               ),
           ];
           const { errors, failed } = schemas.reduce<{
@@ -211,7 +211,7 @@ export const OpenPaymentMandateSchema = z
                       failed: failed + 1,
                     }
                   : { errors, failed })(schema.safeParse(x)),
-            { errors: [], failed: 0 },
+            { errors: [], failed: 0 }
           );
           const passed = schemas.length - failed;
           if (passed !== 1) {
@@ -219,113 +219,113 @@ export const OpenPaymentMandateSchema = z
               errors.length
                 ? {
                     path: [],
-                    code: 'invalid_union',
+                    code: "invalid_union",
                     errors: [errors],
                     message:
-                      'Invalid input: Should pass single schema. Passed ' +
+                      "Invalid input: Should pass single schema. Passed " +
                       passed,
                   }
                 : {
                     path: [],
-                    code: 'custom',
+                    code: "custom",
                     errors: [errors],
                     message:
-                      'Invalid input: Should pass single schema. Passed ' +
+                      "Invalid input: Should pass single schema. Passed " +
                       passed,
-                  },
+                  }
             );
           }
-        }),
+        })
       )
       .describe(
-        'Array of constraints that the future checkout action must abide by.',
+        "Array of constraints that the future checkout action must abide by."
       ),
     cnf: z
       .record(z.string(), z.any())
       .describe(
-        'Confirmation claim as defined in RFC 7800 section 3.1. Used for key binding.',
+        "Confirmation claim as defined in RFC 7800 section 3.1. Used for key binding."
       ),
     payee: z
       .object({
-        id: z.string().describe('Unique identifier for the merchant.'),
-        name: z.string().describe('Human-readable name of the merchant.'),
+        id: z.string().describe("Unique identifier for the merchant."),
+        name: z.string().describe("Human-readable name of the merchant."),
         website: z
           .string()
-          .describe('Website belonging to the merchant.')
+          .describe("Website belonging to the merchant.")
           .optional(),
       })
-      .describe('Schema defining a Mechant object')
+      .describe("Schema defining a Mechant object")
       .optional(),
     payment_amount: z
       .object({
         amount: z
           .number()
           .int()
-          .describe('Amount in minor units, according to the ISO-4217 spec.'),
+          .describe("Amount in minor units, according to the ISO-4217 spec."),
         currency: z
           .string()
           .describe(
-            'ISO-4217 3-letter alphabetic currency code of the payment.',
+            "ISO-4217 3-letter alphabetic currency code of the payment."
           ),
       })
       .describe(
-        'Transaction amount object containing currency (ISO 4217 code, e.g., "USD") and amount (integer minor units per ISO 4217, e.g., 27999 = $279.99). Pre-set by the user at time of mandate creation.',
+        'Transaction amount object containing currency (ISO 4217 code, e.g., "USD") and amount (integer minor units per ISO 4217, e.g., 27999 = $279.99). Pre-set by the user at time of mandate creation.'
       )
       .optional(),
     payment_instrument: z
       .object({
-        id: z.string().describe('unique identifier for this instrument'),
+        id: z.string().describe("unique identifier for this instrument"),
         type: z
           .string()
-          .describe('unique string identifying this category of instrument'),
+          .describe("unique string identifying this category of instrument"),
         description: z
           .string()
           .describe(
-            'Description of the instrument to be displayed to the user for informational purposes',
+            "Description of the instrument to be displayed to the user for informational purposes"
           )
           .optional(),
       })
-      .describe('Instrument used for payment.')
+      .describe("Instrument used for payment.")
       .optional(),
     pisp: z
       .object({
-        legal_name: z.string().describe('Legal name of the PISP.'),
-        brand_name: z.string().describe('Brand name of the PISP.'),
+        legal_name: z.string().describe("Legal name of the PISP."),
+        brand_name: z.string().describe("Brand name of the PISP."),
         domain_name: z
           .string()
           .describe(
-            'Domain name of the PISP as secured by the [eIDAS] QWAC certificate of the TPP.',
+            "Domain name of the PISP as secured by the [eIDAS] QWAC certificate of the TPP."
           ),
       })
       .describe(
-        'Schema defining a Payment Initiation Service Provider (PISP) object',
+        "Schema defining a Payment Initiation Service Provider (PISP) object"
       )
       .optional(),
     execution_date: z
       .string()
       .describe(
-        'ISO8601 date of execution of payment. When absent indicates immediate execution.',
+        "ISO8601 date of execution of payment. When absent indicates immediate execution."
       )
       .optional(),
     risk_data: z
       .record(z.string(), z.any())
       .describe(
-        'An map of relevant risk signals collected by the trusted surface at time of mandate creation.',
+        "An map of relevant risk signals collected by the trusted surface at time of mandate creation."
       )
       .optional(),
     iat: z
       .number()
       .int()
-      .describe('The creation timestamp as a Unix epoch.')
+      .describe("The creation timestamp as a Unix epoch.")
       .optional(),
     exp: z
       .number()
       .int()
-      .describe('The expiration timestamp as a Unix epoch.')
+      .describe("The expiration timestamp as a Unix epoch.")
       .optional(),
   })
   .describe(
-    'Agreement between a user and an agent (or chain of agents) to authorize future payment actions.',
+    "Agreement between a user and an agent (or chain of agents) to authorize future payment actions."
   );
 
 export type OpenPaymentMandate = z.infer<typeof OpenPaymentMandateSchema>;

--- a/code/sdk/typescript/src/generated/mandates/payment-mandate.ts
+++ b/code/sdk/typescript/src/generated/mandates/payment-mandate.ts
@@ -1,96 +1,96 @@
 // Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
 
-import { z } from 'zod';
+import { z } from "zod";
 
 export const PaymentMandateSchema = z
   .object({
     vct: z
-      .literal('mandate.payment.1')
+      .literal("mandate.payment.1")
       .describe(
-        "Verifiable Credential Type claim as defined in SD-JWT. MUST be 'mandate.payment'.",
+        "Verifiable Credential Type claim as defined in SD-JWT. MUST be 'mandate.payment'."
       )
-      .default('mandate.payment.1'),
+      .default("mandate.payment.1"),
     transaction_id: z
       .string()
       .describe(
-        'base64url-encoded hash of the checkout_jwt field value, uniquely identifying the checkout associated with this. The hash algorithm used MUST be the same as the sd_hash field for this sd-jwt, or sha256 if absent.',
+        "base64url-encoded hash of the checkout_jwt field value, uniquely identifying the checkout associated with this. The hash algorithm used MUST be the same as the sd_hash field for this sd-jwt, or sha256 if absent."
       ),
     payee: z
       .object({
-        id: z.string().describe('Unique identifier for the merchant.'),
-        name: z.string().describe('Human-readable name of the merchant.'),
+        id: z.string().describe("Unique identifier for the merchant."),
+        name: z.string().describe("Human-readable name of the merchant."),
         website: z
           .string()
-          .describe('Website belonging to the merchant.')
+          .describe("Website belonging to the merchant.")
           .optional(),
       })
-      .describe('The merchant receiving the payment.'),
+      .describe("The merchant receiving the payment."),
     pisp: z
       .object({
-        legal_name: z.string().describe('Legal name of the PISP.'),
-        brand_name: z.string().describe('Brand name of the PISP.'),
+        legal_name: z.string().describe("Legal name of the PISP."),
+        brand_name: z.string().describe("Brand name of the PISP."),
         domain_name: z
           .string()
           .describe(
-            'Domain name of the PISP as secured by the [eIDAS] QWAC certificate of the TPP.',
+            "Domain name of the PISP as secured by the [eIDAS] QWAC certificate of the TPP."
           ),
       })
-      .describe('The Payment Initiation Service Provider.')
+      .describe("The Payment Initiation Service Provider.")
       .optional(),
     payment_amount: z
       .object({
         amount: z
           .number()
           .int()
-          .describe('Amount in minor units, according to the ISO-4217 spec.'),
+          .describe("Amount in minor units, according to the ISO-4217 spec."),
         currency: z
           .string()
           .describe(
-            'ISO-4217 3-letter alphabetic currency code of the payment.',
+            "ISO-4217 3-letter alphabetic currency code of the payment."
           ),
       })
       .describe(
-        'Transaction amount object containing currency (ISO 4217 code, e.g., "USD") and amount (integer minor units per ISO 4217, e.g., 27999 = $279.99). Final value confirmed by the user.',
+        'Transaction amount object containing currency (ISO 4217 code, e.g., "USD") and amount (integer minor units per ISO 4217, e.g., 27999 = $279.99). Final value confirmed by the user.'
       ),
     payment_instrument: z
       .object({
-        id: z.string().describe('unique identifier for this instrument'),
+        id: z.string().describe("unique identifier for this instrument"),
         type: z
           .string()
-          .describe('unique string identifying this category of instrument'),
+          .describe("unique string identifying this category of instrument"),
         description: z
           .string()
           .describe(
-            'Description of the instrument to be displayed to the user for informational purposes',
+            "Description of the instrument to be displayed to the user for informational purposes"
           )
           .optional(),
       })
-      .describe('The payment instrument used.'),
+      .describe("The payment instrument used."),
     execution_date: z
       .string()
       .describe(
-        'ISO8601 date of execution of payment. When absent indicates immediate execution.',
+        "ISO8601 date of execution of payment. When absent indicates immediate execution."
       )
       .optional(),
     risk_data: z
       .record(z.string(), z.any())
       .describe(
-        'An map of relevant risk signals collected by the trusted surface at time of mandate creation.',
+        "An map of relevant risk signals collected by the trusted surface at time of mandate creation."
       )
       .optional(),
     iat: z
       .number()
       .int()
-      .describe('The creation timestamp as a Unix epoch.')
+      .describe("The creation timestamp as a Unix epoch.")
       .optional(),
     exp: z
       .number()
       .int()
-      .describe('The expiration timestamp as a Unix epoch.')
+      .describe("The expiration timestamp as a Unix epoch.")
       .optional(),
   })
   .describe(
-    'Agreement from a User or an Agent to authorize a particular Payment action.',
+    "Agreement from a User or an Agent to authorize a particular Payment action."
   );
 
 export type PaymentMandate = z.infer<typeof PaymentMandateSchema>;

--- a/code/sdk/typescript/src/generated/mandates/payment-mandate.ts
+++ b/code/sdk/typescript/src/generated/mandates/payment-mandate.ts
@@ -1,0 +1,96 @@
+// Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
+
+import { z } from 'zod';
+
+export const PaymentMandateSchema = z
+  .object({
+    vct: z
+      .literal('mandate.payment.1')
+      .describe(
+        "Verifiable Credential Type claim as defined in SD-JWT. MUST be 'mandate.payment'.",
+      )
+      .default('mandate.payment.1'),
+    transaction_id: z
+      .string()
+      .describe(
+        'base64url-encoded hash of the checkout_jwt field value, uniquely identifying the checkout associated with this. The hash algorithm used MUST be the same as the sd_hash field for this sd-jwt, or sha256 if absent.',
+      ),
+    payee: z
+      .object({
+        id: z.string().describe('Unique identifier for the merchant.'),
+        name: z.string().describe('Human-readable name of the merchant.'),
+        website: z
+          .string()
+          .describe('Website belonging to the merchant.')
+          .optional(),
+      })
+      .describe('The merchant receiving the payment.'),
+    pisp: z
+      .object({
+        legal_name: z.string().describe('Legal name of the PISP.'),
+        brand_name: z.string().describe('Brand name of the PISP.'),
+        domain_name: z
+          .string()
+          .describe(
+            'Domain name of the PISP as secured by the [eIDAS] QWAC certificate of the TPP.',
+          ),
+      })
+      .describe('The Payment Initiation Service Provider.')
+      .optional(),
+    payment_amount: z
+      .object({
+        amount: z
+          .number()
+          .int()
+          .describe('Amount in minor units, according to the ISO-4217 spec.'),
+        currency: z
+          .string()
+          .describe(
+            'ISO-4217 3-letter alphabetic currency code of the payment.',
+          ),
+      })
+      .describe(
+        'Transaction amount object containing currency (ISO 4217 code, e.g., "USD") and amount (integer minor units per ISO 4217, e.g., 27999 = $279.99). Final value confirmed by the user.',
+      ),
+    payment_instrument: z
+      .object({
+        id: z.string().describe('unique identifier for this instrument'),
+        type: z
+          .string()
+          .describe('unique string identifying this category of instrument'),
+        description: z
+          .string()
+          .describe(
+            'Description of the instrument to be displayed to the user for informational purposes',
+          )
+          .optional(),
+      })
+      .describe('The payment instrument used.'),
+    execution_date: z
+      .string()
+      .describe(
+        'ISO8601 date of execution of payment. When absent indicates immediate execution.',
+      )
+      .optional(),
+    risk_data: z
+      .record(z.string(), z.any())
+      .describe(
+        'An map of relevant risk signals collected by the trusted surface at time of mandate creation.',
+      )
+      .optional(),
+    iat: z
+      .number()
+      .int()
+      .describe('The creation timestamp as a Unix epoch.')
+      .optional(),
+    exp: z
+      .number()
+      .int()
+      .describe('The expiration timestamp as a Unix epoch.')
+      .optional(),
+  })
+  .describe(
+    'Agreement from a User or an Agent to authorize a particular Payment action.',
+  );
+
+export type PaymentMandate = z.infer<typeof PaymentMandateSchema>;

--- a/code/sdk/typescript/src/generated/mandates/payment-receipt.ts
+++ b/code/sdk/typescript/src/generated/mandates/payment-receipt.ts
@@ -1,0 +1,127 @@
+// Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
+
+import { z } from 'zod';
+
+export const PaymentReceiptSchema = z
+  .record(z.string(), z.any())
+  .and(
+    z.any().superRefine((x, ctx) => {
+      const schemas = [
+        z.object({
+          status: z.literal('Success'),
+          iss: z.string().describe('The issuer of the receipt.'),
+          iat: z
+            .number()
+            .int()
+            .describe('The creation timestamp as a Unix epoch.'),
+          reference: z
+            .string()
+            .describe(
+              'The hash of the closed Mandate that this receipt is binding to.',
+            ),
+          error: z
+            .string()
+            .describe(
+              'A unique error code. Present if and only if status is Error.',
+            )
+            .optional(),
+          error_description: z
+            .string()
+            .describe(
+              'A human-readable error description. Present if and only if status is Error.',
+            )
+            .optional(),
+          payment_id: z
+            .string()
+            .describe('A unique identifier for the payment.'),
+          psp_confirmation_id: z
+            .string()
+            .describe(
+              'A unique identifier for the transaction confirmation at the PSP. Present only if status is Success.',
+            ),
+          network_confirmation_id: z
+            .string()
+            .describe(
+              'A unique identifier for the transaction confirmation at the network. Present only if status is Success.',
+            ),
+        }),
+        z.object({
+          status: z.literal('Error'),
+          iss: z.string().describe('The issuer of the receipt.'),
+          iat: z
+            .number()
+            .int()
+            .describe('The creation timestamp as a Unix epoch.'),
+          reference: z
+            .string()
+            .describe(
+              'The hash of the closed Mandate that this receipt is binding to.',
+            ),
+          error: z
+            .string()
+            .describe(
+              'A unique error code. Present if and only if status is Error.',
+            ),
+          error_description: z
+            .string()
+            .describe(
+              'A human-readable error description. Present if and only if status is Error.',
+            ),
+          payment_id: z
+            .string()
+            .describe('A unique identifier for the payment.'),
+          psp_confirmation_id: z
+            .string()
+            .describe(
+              'A unique identifier for the transaction confirmation at the PSP. Present only if status is Success.',
+            )
+            .optional(),
+          network_confirmation_id: z
+            .string()
+            .describe(
+              'A unique identifier for the transaction confirmation at the network. Present only if status is Success.',
+            )
+            .optional(),
+        }),
+      ];
+      const { errors, failed } = schemas.reduce<{
+        errors: z.core.$ZodIssue[];
+        failed: number;
+      }>(
+        ({ errors, failed }, schema) =>
+          ((result) =>
+            result.error
+              ? {
+                  errors: [...errors, ...result.error.issues],
+                  failed: failed + 1,
+                }
+              : { errors, failed })(schema.safeParse(x)),
+        { errors: [], failed: 0 },
+      );
+      const passed = schemas.length - failed;
+      if (passed !== 1) {
+        ctx.addIssue(
+          errors.length
+            ? {
+                path: [],
+                code: 'invalid_union',
+                errors: [errors],
+                message:
+                  'Invalid input: Should pass single schema. Passed ' + passed,
+              }
+            : {
+                path: [],
+                code: 'custom',
+                errors: [errors],
+                message:
+                  'Invalid input: Should pass single schema. Passed ' + passed,
+              },
+        );
+      }
+    }),
+  )
+  .describe(
+    'Receipt that supplies information about the final state of a payment.',
+  );
+
+export type PaymentReceipt = z.infer<typeof PaymentReceiptSchema>;

--- a/code/sdk/typescript/src/generated/mandates/payment-receipt.ts
+++ b/code/sdk/typescript/src/generated/mandates/payment-receipt.ts
@@ -1,6 +1,6 @@
 // Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
 
-import { z } from 'zod';
+import { z } from "zod";
 
 export const PaymentReceiptSchema = z
   .record(z.string(), z.any())
@@ -8,78 +8,78 @@ export const PaymentReceiptSchema = z
     z.any().superRefine((x, ctx) => {
       const schemas = [
         z.object({
-          status: z.literal('Success'),
-          iss: z.string().describe('The issuer of the receipt.'),
+          status: z.literal("Success"),
+          iss: z.string().describe("The issuer of the receipt."),
           iat: z
             .number()
             .int()
-            .describe('The creation timestamp as a Unix epoch.'),
+            .describe("The creation timestamp as a Unix epoch."),
           reference: z
             .string()
             .describe(
-              'The hash of the closed Mandate that this receipt is binding to.',
+              "The hash of the closed Mandate that this receipt is binding to."
             ),
           error: z
             .string()
             .describe(
-              'A unique error code. Present if and only if status is Error.',
+              "A unique error code. Present if and only if status is Error."
             )
             .optional(),
           error_description: z
             .string()
             .describe(
-              'A human-readable error description. Present if and only if status is Error.',
+              "A human-readable error description. Present if and only if status is Error."
             )
             .optional(),
           payment_id: z
             .string()
-            .describe('A unique identifier for the payment.'),
+            .describe("A unique identifier for the payment."),
           psp_confirmation_id: z
             .string()
             .describe(
-              'A unique identifier for the transaction confirmation at the PSP. Present only if status is Success.',
+              "A unique identifier for the transaction confirmation at the PSP. Present only if status is Success."
             ),
           network_confirmation_id: z
             .string()
             .describe(
-              'A unique identifier for the transaction confirmation at the network. Present only if status is Success.',
+              "A unique identifier for the transaction confirmation at the network. Present only if status is Success."
             ),
         }),
         z.object({
-          status: z.literal('Error'),
-          iss: z.string().describe('The issuer of the receipt.'),
+          status: z.literal("Error"),
+          iss: z.string().describe("The issuer of the receipt."),
           iat: z
             .number()
             .int()
-            .describe('The creation timestamp as a Unix epoch.'),
+            .describe("The creation timestamp as a Unix epoch."),
           reference: z
             .string()
             .describe(
-              'The hash of the closed Mandate that this receipt is binding to.',
+              "The hash of the closed Mandate that this receipt is binding to."
             ),
           error: z
             .string()
             .describe(
-              'A unique error code. Present if and only if status is Error.',
+              "A unique error code. Present if and only if status is Error."
             ),
           error_description: z
             .string()
             .describe(
-              'A human-readable error description. Present if and only if status is Error.',
+              "A human-readable error description. Present if and only if status is Error."
             ),
           payment_id: z
             .string()
-            .describe('A unique identifier for the payment.'),
+            .describe("A unique identifier for the payment."),
           psp_confirmation_id: z
             .string()
             .describe(
-              'A unique identifier for the transaction confirmation at the PSP. Present only if status is Success.',
+              "A unique identifier for the transaction confirmation at the PSP. Present only if status is Success."
             )
             .optional(),
           network_confirmation_id: z
             .string()
             .describe(
-              'A unique identifier for the transaction confirmation at the network. Present only if status is Success.',
+              "A unique identifier for the transaction confirmation at the network. Present only if status is Success."
             )
             .optional(),
         }),
@@ -96,7 +96,7 @@ export const PaymentReceiptSchema = z
                   failed: failed + 1,
                 }
               : { errors, failed })(schema.safeParse(x)),
-        { errors: [], failed: 0 },
+        { errors: [], failed: 0 }
       );
       const passed = schemas.length - failed;
       if (passed !== 1) {
@@ -104,24 +104,24 @@ export const PaymentReceiptSchema = z
           errors.length
             ? {
                 path: [],
-                code: 'invalid_union',
+                code: "invalid_union",
                 errors: [errors],
                 message:
-                  'Invalid input: Should pass single schema. Passed ' + passed,
+                  "Invalid input: Should pass single schema. Passed " + passed,
               }
             : {
                 path: [],
-                code: 'custom',
+                code: "custom",
                 errors: [errors],
                 message:
-                  'Invalid input: Should pass single schema. Passed ' + passed,
-              },
+                  "Invalid input: Should pass single schema. Passed " + passed,
+              }
         );
       }
-    }),
+    })
   )
   .describe(
-    'Receipt that supplies information about the final state of a payment.',
+    "Receipt that supplies information about the final state of a payment."
   );
 
 export type PaymentReceipt = z.infer<typeof PaymentReceiptSchema>;

--- a/code/sdk/typescript/src/generated/types/amount.ts
+++ b/code/sdk/typescript/src/generated/types/amount.ts
@@ -1,0 +1,17 @@
+// Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
+
+import { z } from 'zod';
+
+export const AmountSchema = z
+  .object({
+    amount: z
+      .number()
+      .int()
+      .describe('Amount in minor units, according to the ISO-4217 spec.'),
+    currency: z
+      .string()
+      .describe('ISO-4217 3-letter alphabetic currency code of the payment.'),
+  })
+  .describe('Schema defining an Amount and Current object');
+
+export type Amount = z.infer<typeof AmountSchema>;

--- a/code/sdk/typescript/src/generated/types/amount.ts
+++ b/code/sdk/typescript/src/generated/types/amount.ts
@@ -1,17 +1,17 @@
 // Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
 
-import { z } from 'zod';
+import { z } from "zod";
 
 export const AmountSchema = z
   .object({
     amount: z
       .number()
       .int()
-      .describe('Amount in minor units, according to the ISO-4217 spec.'),
+      .describe("Amount in minor units, according to the ISO-4217 spec."),
     currency: z
       .string()
-      .describe('ISO-4217 3-letter alphabetic currency code of the payment.'),
+      .describe("ISO-4217 3-letter alphabetic currency code of the payment."),
   })
-  .describe('Schema defining an Amount and Current object');
+  .describe("Schema defining an Amount and Current object");
 
 export type Amount = z.infer<typeof AmountSchema>;

--- a/code/sdk/typescript/src/generated/types/item.ts
+++ b/code/sdk/typescript/src/generated/types/item.ts
@@ -1,0 +1,26 @@
+// Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
+
+import { z } from 'zod';
+
+export const ItemSchema = z
+  .object({
+    id: z
+      .string()
+      .describe(
+        'The product identifier, often the SKU, required to resolve the product details associated with this line item.',
+      ),
+    title: z.string().describe('Product title.'),
+    price: z
+      .number()
+      .int()
+      .gte(0)
+      .describe(
+        "Unit price in the currency's minor unit as defined by ISO 4217.",
+      ),
+    image_url: z.string().url().describe('Product image URI.').optional(),
+  })
+  .describe(
+    'Product details for a line item. Matches UCP types/item.json (2026-04-08).',
+  );
+
+export type Item = z.infer<typeof ItemSchema>;

--- a/code/sdk/typescript/src/generated/types/item.ts
+++ b/code/sdk/typescript/src/generated/types/item.ts
@@ -1,26 +1,26 @@
 // Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
 
-import { z } from 'zod';
+import { z } from "zod";
 
 export const ItemSchema = z
   .object({
     id: z
       .string()
       .describe(
-        'The product identifier, often the SKU, required to resolve the product details associated with this line item.',
+        "The product identifier, often the SKU, required to resolve the product details associated with this line item."
       ),
-    title: z.string().describe('Product title.'),
+    title: z.string().describe("Product title."),
     price: z
       .number()
       .int()
       .gte(0)
       .describe(
-        "Unit price in the currency's minor unit as defined by ISO 4217.",
+        "Unit price in the currency's minor unit as defined by ISO 4217."
       ),
-    image_url: z.string().url().describe('Product image URI.').optional(),
+    image_url: z.string().url().describe("Product image URI.").optional(),
   })
   .describe(
-    'Product details for a line item. Matches UCP types/item.json (2026-04-08).',
+    "Product details for a line item. Matches UCP types/item.json (2026-04-08)."
   );
 
 export type Item = z.infer<typeof ItemSchema>;

--- a/code/sdk/typescript/src/generated/types/jwk.ts
+++ b/code/sdk/typescript/src/generated/types/jwk.ts
@@ -1,77 +1,77 @@
 // Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
 
-import { z } from 'zod';
+import { z } from "zod";
 
 export const JwkSchema = z
   .object({
-    kty: z.literal('EC').describe('Key type.'),
-    crv: z.literal('P-256').describe('Curve name.').optional(),
+    kty: z.literal("EC").describe("Key type."),
+    crv: z.literal("P-256").describe("Curve name.").optional(),
     x: z
       .string()
-      .regex(new RegExp('^[A-Za-z0-9_-]{43}$'))
-      .describe('Base64url-encoded x coordinate of the EC public key.')
+      .regex(new RegExp("^[A-Za-z0-9_-]{43}$"))
+      .describe("Base64url-encoded x coordinate of the EC public key.")
       .optional(),
     y: z
       .string()
-      .regex(new RegExp('^[A-Za-z0-9_-]{43}$'))
-      .describe('Base64url-encoded y coordinate of the EC public key.')
+      .regex(new RegExp("^[A-Za-z0-9_-]{43}$"))
+      .describe("Base64url-encoded y coordinate of the EC public key.")
       .optional(),
     use: z
-      .enum(['sig', 'enc'])
+      .enum(["sig", "enc"])
       .describe("Public key use. 'sig' for signature, 'enc' for encryption.")
       .optional(),
     key_ops: z
       .array(
         z.enum([
-          'sign',
-          'verify',
-          'encrypt',
-          'decrypt',
-          'wrapKey',
-          'unwrapKey',
-          'deriveKey',
-          'deriveBits',
-        ]),
+          "sign",
+          "verify",
+          "encrypt",
+          "decrypt",
+          "wrapKey",
+          "unwrapKey",
+          "deriveKey",
+          "deriveBits",
+        ])
       )
       .describe(
-        'Key operations. Identifies the operations the key is intended for.',
+        "Key operations. Identifies the operations the key is intended for."
       )
       .optional(),
     alg: z
-      .literal('ES256')
+      .literal("ES256")
       .describe("Algorithm. Must be 'ES256' for P-256 curve signing.")
       .optional(),
     kid: z
       .string()
-      .describe('Key ID (§4.5). Arbitrary string used to match a specific key.')
+      .describe("Key ID (§4.5). Arbitrary string used to match a specific key.")
       .optional(),
     x5u: z
       .string()
       .url()
       .describe(
-        'X.509 URL (§4.6). URI pointing to an X.509 public key certificate or chain.',
+        "X.509 URL (§4.6). URI pointing to an X.509 public key certificate or chain."
       )
       .optional(),
     x5c: z
       .array(z.string())
       .describe(
-        'X.509 certificate chain (§4.7). Array of base64-encoded (not base64url) DER PKIX certificates.',
+        "X.509 certificate chain (§4.7). Array of base64-encoded (not base64url) DER PKIX certificates."
       )
       .optional(),
     x5t: z
       .string()
       .describe(
-        'X.509 SHA-1 thumbprint (§4.8). Base64url-encoded SHA-1 digest of the DER encoding of the certificate.',
+        "X.509 SHA-1 thumbprint (§4.8). Base64url-encoded SHA-1 digest of the DER encoding of the certificate."
       )
       .optional(),
-    'x5t#S256': z
+    "x5t#S256": z
       .string()
       .describe(
-        'X.509 SHA-256 thumbprint (§4.9). Base64url-encoded SHA-256 digest of the DER encoding of the certificate.',
+        "X.509 SHA-256 thumbprint (§4.9). Base64url-encoded SHA-256 digest of the DER encoding of the certificate."
       )
       .optional(),
   })
   .strict()
-  .describe('An EC P-256 public key in JWK format (RFC 7517).');
+  .describe("An EC P-256 public key in JWK format (RFC 7517).");
 
 export type Jwk = z.infer<typeof JwkSchema>;

--- a/code/sdk/typescript/src/generated/types/jwk.ts
+++ b/code/sdk/typescript/src/generated/types/jwk.ts
@@ -1,0 +1,77 @@
+// Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
+
+import { z } from 'zod';
+
+export const JwkSchema = z
+  .object({
+    kty: z.literal('EC').describe('Key type.'),
+    crv: z.literal('P-256').describe('Curve name.').optional(),
+    x: z
+      .string()
+      .regex(new RegExp('^[A-Za-z0-9_-]{43}$'))
+      .describe('Base64url-encoded x coordinate of the EC public key.')
+      .optional(),
+    y: z
+      .string()
+      .regex(new RegExp('^[A-Za-z0-9_-]{43}$'))
+      .describe('Base64url-encoded y coordinate of the EC public key.')
+      .optional(),
+    use: z
+      .enum(['sig', 'enc'])
+      .describe("Public key use. 'sig' for signature, 'enc' for encryption.")
+      .optional(),
+    key_ops: z
+      .array(
+        z.enum([
+          'sign',
+          'verify',
+          'encrypt',
+          'decrypt',
+          'wrapKey',
+          'unwrapKey',
+          'deriveKey',
+          'deriveBits',
+        ]),
+      )
+      .describe(
+        'Key operations. Identifies the operations the key is intended for.',
+      )
+      .optional(),
+    alg: z
+      .literal('ES256')
+      .describe("Algorithm. Must be 'ES256' for P-256 curve signing.")
+      .optional(),
+    kid: z
+      .string()
+      .describe('Key ID (§4.5). Arbitrary string used to match a specific key.')
+      .optional(),
+    x5u: z
+      .string()
+      .url()
+      .describe(
+        'X.509 URL (§4.6). URI pointing to an X.509 public key certificate or chain.',
+      )
+      .optional(),
+    x5c: z
+      .array(z.string())
+      .describe(
+        'X.509 certificate chain (§4.7). Array of base64-encoded (not base64url) DER PKIX certificates.',
+      )
+      .optional(),
+    x5t: z
+      .string()
+      .describe(
+        'X.509 SHA-1 thumbprint (§4.8). Base64url-encoded SHA-1 digest of the DER encoding of the certificate.',
+      )
+      .optional(),
+    'x5t#S256': z
+      .string()
+      .describe(
+        'X.509 SHA-256 thumbprint (§4.9). Base64url-encoded SHA-256 digest of the DER encoding of the certificate.',
+      )
+      .optional(),
+  })
+  .strict()
+  .describe('An EC P-256 public key in JWK format (RFC 7517).');
+
+export type Jwk = z.infer<typeof JwkSchema>;

--- a/code/sdk/typescript/src/generated/types/merchant.ts
+++ b/code/sdk/typescript/src/generated/types/merchant.ts
@@ -1,0 +1,16 @@
+// Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
+
+import { z } from 'zod';
+
+export const MerchantSchema = z
+  .object({
+    id: z.string().describe('Unique identifier for the merchant.'),
+    name: z.string().describe('Human-readable name of the merchant.'),
+    website: z
+      .string()
+      .describe('Website belonging to the merchant.')
+      .optional(),
+  })
+  .describe('Schema defining a Mechant object');
+
+export type Merchant = z.infer<typeof MerchantSchema>;

--- a/code/sdk/typescript/src/generated/types/merchant.ts
+++ b/code/sdk/typescript/src/generated/types/merchant.ts
@@ -1,16 +1,16 @@
 // Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
 
-import { z } from 'zod';
+import { z } from "zod";
 
 export const MerchantSchema = z
   .object({
-    id: z.string().describe('Unique identifier for the merchant.'),
-    name: z.string().describe('Human-readable name of the merchant.'),
+    id: z.string().describe("Unique identifier for the merchant."),
+    name: z.string().describe("Human-readable name of the merchant."),
     website: z
       .string()
-      .describe('Website belonging to the merchant.')
+      .describe("Website belonging to the merchant.")
       .optional(),
   })
-  .describe('Schema defining a Mechant object');
+  .describe("Schema defining a Mechant object");
 
 export type Merchant = z.infer<typeof MerchantSchema>;

--- a/code/sdk/typescript/src/generated/types/payment-instrument.ts
+++ b/code/sdk/typescript/src/generated/types/payment-instrument.ts
@@ -1,0 +1,20 @@
+// Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
+
+import { z } from 'zod';
+
+export const PaymentInstrumentSchema = z
+  .object({
+    id: z.string().describe('unique identifier for this instrument'),
+    type: z
+      .string()
+      .describe('unique string identifying this category of instrument'),
+    description: z
+      .string()
+      .describe(
+        'Description of the instrument to be displayed to the user for informational purposes',
+      )
+      .optional(),
+  })
+  .describe('Instrument used for payment.');
+
+export type PaymentInstrument = z.infer<typeof PaymentInstrumentSchema>;

--- a/code/sdk/typescript/src/generated/types/payment-instrument.ts
+++ b/code/sdk/typescript/src/generated/types/payment-instrument.ts
@@ -1,20 +1,20 @@
 // Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
 
-import { z } from 'zod';
+import { z } from "zod";
 
 export const PaymentInstrumentSchema = z
   .object({
-    id: z.string().describe('unique identifier for this instrument'),
+    id: z.string().describe("unique identifier for this instrument"),
     type: z
       .string()
-      .describe('unique string identifying this category of instrument'),
+      .describe("unique string identifying this category of instrument"),
     description: z
       .string()
       .describe(
-        'Description of the instrument to be displayed to the user for informational purposes',
+        "Description of the instrument to be displayed to the user for informational purposes"
       )
       .optional(),
   })
-  .describe('Instrument used for payment.');
+  .describe("Instrument used for payment.");
 
 export type PaymentInstrument = z.infer<typeof PaymentInstrumentSchema>;

--- a/code/sdk/typescript/src/generated/types/pisp.ts
+++ b/code/sdk/typescript/src/generated/types/pisp.ts
@@ -1,19 +1,19 @@
 // Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
 
-import { z } from 'zod';
+import { z } from "zod";
 
 export const PispSchema = z
   .object({
-    legal_name: z.string().describe('Legal name of the PISP.'),
-    brand_name: z.string().describe('Brand name of the PISP.'),
+    legal_name: z.string().describe("Legal name of the PISP."),
+    brand_name: z.string().describe("Brand name of the PISP."),
     domain_name: z
       .string()
       .describe(
-        'Domain name of the PISP as secured by the [eIDAS] QWAC certificate of the TPP.',
+        "Domain name of the PISP as secured by the [eIDAS] QWAC certificate of the TPP."
       ),
   })
   .describe(
-    'Schema defining a Payment Initiation Service Provider (PISP) object',
+    "Schema defining a Payment Initiation Service Provider (PISP) object"
   );
 
 export type Pisp = z.infer<typeof PispSchema>;

--- a/code/sdk/typescript/src/generated/types/pisp.ts
+++ b/code/sdk/typescript/src/generated/types/pisp.ts
@@ -1,0 +1,19 @@
+// Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
+
+import { z } from 'zod';
+
+export const PispSchema = z
+  .object({
+    legal_name: z.string().describe('Legal name of the PISP.'),
+    brand_name: z.string().describe('Brand name of the PISP.'),
+    domain_name: z
+      .string()
+      .describe(
+        'Domain name of the PISP as secured by the [eIDAS] QWAC certificate of the TPP.',
+      ),
+  })
+  .describe(
+    'Schema defining a Payment Initiation Service Provider (PISP) object',
+  );
+
+export type Pisp = z.infer<typeof PispSchema>;

--- a/code/sdk/typescript/src/generated/types/receipt-status.ts
+++ b/code/sdk/typescript/src/generated/types/receipt-status.ts
@@ -1,9 +1,9 @@
 // Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
 
-import { z } from 'zod';
+import { z } from "zod";
 
 export const ReceiptStatusSchema = z
-  .enum(['Success', 'Error'])
-  .describe('The status of a receipt.');
+  .enum(["Success", "Error"])
+  .describe("The status of a receipt.");
 
 export type ReceiptStatus = z.infer<typeof ReceiptStatusSchema>;

--- a/code/sdk/typescript/src/generated/types/receipt-status.ts
+++ b/code/sdk/typescript/src/generated/types/receipt-status.ts
@@ -1,0 +1,9 @@
+// Code generated from code/sdk/schemas/ap2 by scripts/generate.ts. DO NOT EDIT.
+
+import { z } from 'zod';
+
+export const ReceiptStatusSchema = z
+  .enum(['Success', 'Error'])
+  .describe('The status of a receipt.');
+
+export type ReceiptStatus = z.infer<typeof ReceiptStatusSchema>;

--- a/code/sdk/typescript/src/index.ts
+++ b/code/sdk/typescript/src/index.ts
@@ -1,38 +1,38 @@
 export {
   CheckoutMandateSchema,
   type CheckoutMandate,
-} from './generated/mandates/checkout-mandate.js';
+} from "./generated/mandates/checkout-mandate.js";
 export {
   CheckoutReceiptSchema,
   type CheckoutReceipt,
-} from './generated/mandates/checkout-receipt.js';
+} from "./generated/mandates/checkout-receipt.js";
 export {
   OpenCheckoutMandateSchema,
   type OpenCheckoutMandate,
-} from './generated/mandates/open-checkout-mandate.js';
+} from "./generated/mandates/open-checkout-mandate.js";
 export {
   OpenPaymentMandateSchema,
   type OpenPaymentMandate,
-} from './generated/mandates/open-payment-mandate.js';
+} from "./generated/mandates/open-payment-mandate.js";
 export {
   PaymentMandateSchema,
   type PaymentMandate,
-} from './generated/mandates/payment-mandate.js';
+} from "./generated/mandates/payment-mandate.js";
 export {
   PaymentReceiptSchema,
   type PaymentReceipt,
-} from './generated/mandates/payment-receipt.js';
+} from "./generated/mandates/payment-receipt.js";
 
-export { AmountSchema, type Amount } from './generated/types/amount.js';
-export { ItemSchema, type Item } from './generated/types/item.js';
-export { JwkSchema, type Jwk } from './generated/types/jwk.js';
-export { MerchantSchema, type Merchant } from './generated/types/merchant.js';
+export { AmountSchema, type Amount } from "./generated/types/amount.js";
+export { ItemSchema, type Item } from "./generated/types/item.js";
+export { JwkSchema, type Jwk } from "./generated/types/jwk.js";
+export { MerchantSchema, type Merchant } from "./generated/types/merchant.js";
 export {
   PaymentInstrumentSchema,
   type PaymentInstrument,
-} from './generated/types/payment-instrument.js';
-export { PispSchema, type Pisp } from './generated/types/pisp.js';
+} from "./generated/types/payment-instrument.js";
+export { PispSchema, type Pisp } from "./generated/types/pisp.js";
 export {
   ReceiptStatusSchema,
   type ReceiptStatus,
-} from './generated/types/receipt-status.js';
+} from "./generated/types/receipt-status.js";

--- a/code/sdk/typescript/src/index.ts
+++ b/code/sdk/typescript/src/index.ts
@@ -1,0 +1,38 @@
+export {
+  CheckoutMandateSchema,
+  type CheckoutMandate,
+} from './generated/mandates/checkout-mandate.js';
+export {
+  CheckoutReceiptSchema,
+  type CheckoutReceipt,
+} from './generated/mandates/checkout-receipt.js';
+export {
+  OpenCheckoutMandateSchema,
+  type OpenCheckoutMandate,
+} from './generated/mandates/open-checkout-mandate.js';
+export {
+  OpenPaymentMandateSchema,
+  type OpenPaymentMandate,
+} from './generated/mandates/open-payment-mandate.js';
+export {
+  PaymentMandateSchema,
+  type PaymentMandate,
+} from './generated/mandates/payment-mandate.js';
+export {
+  PaymentReceiptSchema,
+  type PaymentReceipt,
+} from './generated/mandates/payment-receipt.js';
+
+export { AmountSchema, type Amount } from './generated/types/amount.js';
+export { ItemSchema, type Item } from './generated/types/item.js';
+export { JwkSchema, type Jwk } from './generated/types/jwk.js';
+export { MerchantSchema, type Merchant } from './generated/types/merchant.js';
+export {
+  PaymentInstrumentSchema,
+  type PaymentInstrument,
+} from './generated/types/payment-instrument.js';
+export { PispSchema, type Pisp } from './generated/types/pisp.js';
+export {
+  ReceiptStatusSchema,
+  type ReceiptStatus,
+} from './generated/types/receipt-status.js';

--- a/code/sdk/typescript/test/schemas.test.ts
+++ b/code/sdk/typescript/test/schemas.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from "vitest";
 import {
   AmountSchema,
   CheckoutMandateSchema,
@@ -9,111 +9,111 @@ import {
   PaymentInstrumentSchema,
   PaymentMandateSchema,
   PaymentReceiptSchema,
-} from '../src/index.js';
+} from "../src/index.js";
 
 // Mirrors the fixture defaults in
 // code/sdk/python/ap2/tests/conftest.py::sample_payment_mandate, so the two
 // SDKs agree on what a minimal valid mandate looks like.
-describe('PaymentMandateSchema', () => {
-  it('accepts a minimal valid payment mandate', () => {
+describe("PaymentMandateSchema", () => {
+  it("accepts a minimal valid payment mandate", () => {
     const result = PaymentMandateSchema.safeParse({
-      transaction_id: 'tx_1',
-      payee: { id: 's-1', name: 'Shop' },
-      payment_amount: { amount: 1000, currency: 'USD' },
-      payment_instrument: { id: 'pi-1', type: 'credit' },
+      transaction_id: "tx_1",
+      payee: { id: "s-1", name: "Shop" },
+      payment_amount: { amount: 1000, currency: "USD" },
+      payment_instrument: { id: "pi-1", type: "credit" },
     });
     expect(result.success).toBe(true);
   });
 
-  it('applies the vct default', () => {
+  it("applies the vct default", () => {
     const result = PaymentMandateSchema.parse({
-      transaction_id: 'tx_1',
-      payee: { id: 's-1', name: 'Shop' },
-      payment_amount: { amount: 1000, currency: 'USD' },
-      payment_instrument: { id: 'pi-1', type: 'credit' },
+      transaction_id: "tx_1",
+      payee: { id: "s-1", name: "Shop" },
+      payment_amount: { amount: 1000, currency: "USD" },
+      payment_instrument: { id: "pi-1", type: "credit" },
     });
-    expect(result.vct).toBe('mandate.payment.1');
+    expect(result.vct).toBe("mandate.payment.1");
   });
 
-  it('rejects a mismatched vct literal', () => {
+  it("rejects a mismatched vct literal", () => {
     const result = PaymentMandateSchema.safeParse({
-      vct: 'mandate.checkout.1',
-      transaction_id: 'tx_1',
-      payee: { id: 's-1', name: 'Shop' },
-      payment_amount: { amount: 1000, currency: 'USD' },
-      payment_instrument: { id: 'pi-1', type: 'credit' },
+      vct: "mandate.checkout.1",
+      transaction_id: "tx_1",
+      payee: { id: "s-1", name: "Shop" },
+      payment_amount: { amount: 1000, currency: "USD" },
+      payment_instrument: { id: "pi-1", type: "credit" },
     });
     expect(result.success).toBe(false);
   });
 
-  it('rejects a missing required field', () => {
+  it("rejects a missing required field", () => {
     const result = PaymentMandateSchema.safeParse({
-      transaction_id: 'tx_1',
-      payee: { id: 's-1', name: 'Shop' },
-      payment_instrument: { id: 'pi-1', type: 'credit' },
+      transaction_id: "tx_1",
+      payee: { id: "s-1", name: "Shop" },
+      payment_instrument: { id: "pi-1", type: "credit" },
     });
     expect(result.success).toBe(false);
   });
 });
 
-describe('CheckoutMandateSchema', () => {
-  it('accepts a minimal valid checkout mandate', () => {
+describe("CheckoutMandateSchema", () => {
+  it("accepts a minimal valid checkout mandate", () => {
     const result = CheckoutMandateSchema.safeParse({
-      checkout_jwt: 'ZmFrZS1qd3Q',
-      checkout_hash: 'ZmFrZS1oYXNo',
+      checkout_jwt: "ZmFrZS1qd3Q",
+      checkout_hash: "ZmFrZS1oYXNo",
     });
     expect(result.success).toBe(true);
   });
 
-  it('rejects a missing checkout_hash', () => {
+  it("rejects a missing checkout_hash", () => {
     const result = CheckoutMandateSchema.safeParse({
-      checkout_jwt: 'ZmFrZS1qd3Q',
+      checkout_jwt: "ZmFrZS1qd3Q",
     });
     expect(result.success).toBe(false);
   });
 });
 
-describe('OpenPaymentMandateSchema', () => {
-  it('accepts an open payment mandate with an amount_range constraint', () => {
+describe("OpenPaymentMandateSchema", () => {
+  it("accepts an open payment mandate with an amount_range constraint", () => {
     const result = OpenPaymentMandateSchema.safeParse({
       constraints: [
-        { type: 'payment.amount_range', currency: 'USD', max: 5000 },
+        { type: "payment.amount_range", currency: "USD", max: 5000 },
       ],
-      cnf: { jwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' } },
+      cnf: { jwk: { kty: "EC", crv: "P-256", x: "x", y: "y" } },
     });
     expect(result.success).toBe(true);
   });
 
-  it('rejects a constraint entry that matches none of the known constraint types', () => {
+  it("rejects a constraint entry that matches none of the known constraint types", () => {
     const result = OpenPaymentMandateSchema.safeParse({
-      constraints: [{ type: 'not.a.real.constraint' }],
-      cnf: { jwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' } },
+      constraints: [{ type: "not.a.real.constraint" }],
+      cnf: { jwk: { kty: "EC", crv: "P-256", x: "x", y: "y" } },
     });
     expect(result.success).toBe(false);
   });
 });
 
-describe('OpenCheckoutMandateSchema', () => {
-  it('accepts a minimal valid open checkout mandate', () => {
+describe("OpenCheckoutMandateSchema", () => {
+  it("accepts a minimal valid open checkout mandate", () => {
     const result = OpenCheckoutMandateSchema.safeParse({
       constraints: [
         {
-          type: 'checkout.line_items',
+          type: "checkout.line_items",
           items: [
             {
-              id: 'req-1',
-              acceptable_items: [{ id: 'sku-1', title: 'Widget' }],
+              id: "req-1",
+              acceptable_items: [{ id: "sku-1", title: "Widget" }],
               quantity: 1,
             },
           ],
         },
       ],
-      cnf: { jwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' } },
+      cnf: { jwk: { kty: "EC", crv: "P-256", x: "x", y: "y" } },
     });
     expect(result.success).toBe(true);
   });
 
-  it('rejects a missing cnf', () => {
+  it("rejects a missing cnf", () => {
     const result = OpenCheckoutMandateSchema.safeParse({
       constraints: [],
     });
@@ -121,97 +121,96 @@ describe('OpenCheckoutMandateSchema', () => {
   });
 });
 
-describe('PaymentReceiptSchema', () => {
+describe("PaymentReceiptSchema", () => {
   const base = {
-    iss: 'issuer',
+    iss: "issuer",
     iat: 1700000000,
-    reference: 'ref-hash',
-    payment_id: 'pay-1',
+    reference: "ref-hash",
+    payment_id: "pay-1",
   };
 
-  it('accepts a Success receipt with confirmation IDs', () => {
+  it("accepts a Success receipt with confirmation IDs", () => {
     const result = PaymentReceiptSchema.safeParse({
       ...base,
-      status: 'Success',
-      psp_confirmation_id: 'psp-1',
-      network_confirmation_id: 'net-1',
+      status: "Success",
+      psp_confirmation_id: "psp-1",
+      network_confirmation_id: "net-1",
     });
     expect(result.success).toBe(true);
   });
 
-  it('rejects a Success receipt missing confirmation IDs', () => {
+  it("rejects a Success receipt missing confirmation IDs", () => {
     // Regression test for the oneOf-branch-required fix in scripts/generate.ts
     // (materializeSiblingOneOf) — without it this incorrectly validated.
     const result = PaymentReceiptSchema.safeParse({
       ...base,
-      status: 'Success',
+      status: "Success",
     });
     expect(result.success).toBe(false);
   });
 
-  it('accepts an Error receipt with error details', () => {
+  it("accepts an Error receipt with error details", () => {
     const result = PaymentReceiptSchema.safeParse({
       ...base,
-      status: 'Error',
-      error: 'insufficient_funds',
-      error_description: 'The payment instrument was declined.',
+      status: "Error",
+      error: "insufficient_funds",
+      error_description: "The payment instrument was declined.",
     });
     expect(result.success).toBe(true);
   });
 
-  it('rejects an Error receipt missing error details', () => {
+  it("rejects an Error receipt missing error details", () => {
     const result = PaymentReceiptSchema.safeParse({
       ...base,
-      status: 'Error',
+      status: "Error",
     });
     expect(result.success).toBe(false);
   });
 });
 
-describe('CheckoutReceiptSchema', () => {
-  const base = { iss: 'issuer', iat: 1700000000, reference: 'ref-hash' };
+describe("CheckoutReceiptSchema", () => {
+  const base = { iss: "issuer", iat: 1700000000, reference: "ref-hash" };
 
-  it('accepts a Success receipt with an order_id', () => {
+  it("accepts a Success receipt with an order_id", () => {
     const result = CheckoutReceiptSchema.safeParse({
       ...base,
-      status: 'Success',
-      order_id: 'order-1',
+      status: "Success",
+      order_id: "order-1",
     });
     expect(result.success).toBe(true);
   });
 
-  it('rejects a Success receipt missing order_id', () => {
+  it("rejects a Success receipt missing order_id", () => {
     const result = CheckoutReceiptSchema.safeParse({
       ...base,
-      status: 'Success',
+      status: "Success",
     });
     expect(result.success).toBe(false);
   });
 });
 
-describe('shared types', () => {
-  it('validates a Merchant', () => {
-    expect(MerchantSchema.safeParse({ id: 's-1', name: 'Shop' }).success).toBe(
-      true,
+describe("shared types", () => {
+  it("validates a Merchant", () => {
+    expect(MerchantSchema.safeParse({ id: "s-1", name: "Shop" }).success).toBe(
+      true
     );
   });
 
-  it('validates an Amount', () => {
+  it("validates an Amount", () => {
     expect(
-      AmountSchema.safeParse({ amount: 1000, currency: 'USD' }).success,
+      AmountSchema.safeParse({ amount: 1000, currency: "USD" }).success
     ).toBe(true);
   });
 
-  it('rejects an Amount with a non-integer amount', () => {
+  it("rejects an Amount with a non-integer amount", () => {
     expect(
-      AmountSchema.safeParse({ amount: 10.5, currency: 'USD' }).success,
+      AmountSchema.safeParse({ amount: 10.5, currency: "USD" }).success
     ).toBe(false);
   });
 
-  it('validates a PaymentInstrument', () => {
+  it("validates a PaymentInstrument", () => {
     expect(
-      PaymentInstrumentSchema.safeParse({ id: 'pi-1', type: 'credit' })
-        .success,
+      PaymentInstrumentSchema.safeParse({ id: "pi-1", type: "credit" }).success
     ).toBe(true);
   });
 });

--- a/code/sdk/typescript/test/schemas.test.ts
+++ b/code/sdk/typescript/test/schemas.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AmountSchema,
+  CheckoutMandateSchema,
+  CheckoutReceiptSchema,
+  MerchantSchema,
+  OpenCheckoutMandateSchema,
+  OpenPaymentMandateSchema,
+  PaymentInstrumentSchema,
+  PaymentMandateSchema,
+  PaymentReceiptSchema,
+} from '../src/index.js';
+
+// Mirrors the fixture defaults in
+// code/sdk/python/ap2/tests/conftest.py::sample_payment_mandate, so the two
+// SDKs agree on what a minimal valid mandate looks like.
+describe('PaymentMandateSchema', () => {
+  it('accepts a minimal valid payment mandate', () => {
+    const result = PaymentMandateSchema.safeParse({
+      transaction_id: 'tx_1',
+      payee: { id: 's-1', name: 'Shop' },
+      payment_amount: { amount: 1000, currency: 'USD' },
+      payment_instrument: { id: 'pi-1', type: 'credit' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('applies the vct default', () => {
+    const result = PaymentMandateSchema.parse({
+      transaction_id: 'tx_1',
+      payee: { id: 's-1', name: 'Shop' },
+      payment_amount: { amount: 1000, currency: 'USD' },
+      payment_instrument: { id: 'pi-1', type: 'credit' },
+    });
+    expect(result.vct).toBe('mandate.payment.1');
+  });
+
+  it('rejects a mismatched vct literal', () => {
+    const result = PaymentMandateSchema.safeParse({
+      vct: 'mandate.checkout.1',
+      transaction_id: 'tx_1',
+      payee: { id: 's-1', name: 'Shop' },
+      payment_amount: { amount: 1000, currency: 'USD' },
+      payment_instrument: { id: 'pi-1', type: 'credit' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a missing required field', () => {
+    const result = PaymentMandateSchema.safeParse({
+      transaction_id: 'tx_1',
+      payee: { id: 's-1', name: 'Shop' },
+      payment_instrument: { id: 'pi-1', type: 'credit' },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('CheckoutMandateSchema', () => {
+  it('accepts a minimal valid checkout mandate', () => {
+    const result = CheckoutMandateSchema.safeParse({
+      checkout_jwt: 'ZmFrZS1qd3Q',
+      checkout_hash: 'ZmFrZS1oYXNo',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a missing checkout_hash', () => {
+    const result = CheckoutMandateSchema.safeParse({
+      checkout_jwt: 'ZmFrZS1qd3Q',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('OpenPaymentMandateSchema', () => {
+  it('accepts an open payment mandate with an amount_range constraint', () => {
+    const result = OpenPaymentMandateSchema.safeParse({
+      constraints: [
+        { type: 'payment.amount_range', currency: 'USD', max: 5000 },
+      ],
+      cnf: { jwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a constraint entry that matches none of the known constraint types', () => {
+    const result = OpenPaymentMandateSchema.safeParse({
+      constraints: [{ type: 'not.a.real.constraint' }],
+      cnf: { jwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' } },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('OpenCheckoutMandateSchema', () => {
+  it('accepts a minimal valid open checkout mandate', () => {
+    const result = OpenCheckoutMandateSchema.safeParse({
+      constraints: [
+        {
+          type: 'checkout.line_items',
+          items: [
+            {
+              id: 'req-1',
+              acceptable_items: [{ id: 'sku-1', title: 'Widget' }],
+              quantity: 1,
+            },
+          ],
+        },
+      ],
+      cnf: { jwk: { kty: 'EC', crv: 'P-256', x: 'x', y: 'y' } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a missing cnf', () => {
+    const result = OpenCheckoutMandateSchema.safeParse({
+      constraints: [],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('PaymentReceiptSchema', () => {
+  const base = {
+    iss: 'issuer',
+    iat: 1700000000,
+    reference: 'ref-hash',
+    payment_id: 'pay-1',
+  };
+
+  it('accepts a Success receipt with confirmation IDs', () => {
+    const result = PaymentReceiptSchema.safeParse({
+      ...base,
+      status: 'Success',
+      psp_confirmation_id: 'psp-1',
+      network_confirmation_id: 'net-1',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a Success receipt missing confirmation IDs', () => {
+    // Regression test for the oneOf-branch-required fix in scripts/generate.ts
+    // (materializeSiblingOneOf) — without it this incorrectly validated.
+    const result = PaymentReceiptSchema.safeParse({
+      ...base,
+      status: 'Success',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts an Error receipt with error details', () => {
+    const result = PaymentReceiptSchema.safeParse({
+      ...base,
+      status: 'Error',
+      error: 'insufficient_funds',
+      error_description: 'The payment instrument was declined.',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an Error receipt missing error details', () => {
+    const result = PaymentReceiptSchema.safeParse({
+      ...base,
+      status: 'Error',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('CheckoutReceiptSchema', () => {
+  const base = { iss: 'issuer', iat: 1700000000, reference: 'ref-hash' };
+
+  it('accepts a Success receipt with an order_id', () => {
+    const result = CheckoutReceiptSchema.safeParse({
+      ...base,
+      status: 'Success',
+      order_id: 'order-1',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a Success receipt missing order_id', () => {
+    const result = CheckoutReceiptSchema.safeParse({
+      ...base,
+      status: 'Success',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('shared types', () => {
+  it('validates a Merchant', () => {
+    expect(MerchantSchema.safeParse({ id: 's-1', name: 'Shop' }).success).toBe(
+      true,
+    );
+  });
+
+  it('validates an Amount', () => {
+    expect(
+      AmountSchema.safeParse({ amount: 1000, currency: 'USD' }).success,
+    ).toBe(true);
+  });
+
+  it('rejects an Amount with a non-integer amount', () => {
+    expect(
+      AmountSchema.safeParse({ amount: 10.5, currency: 'USD' }).success,
+    ).toBe(false);
+  });
+
+  it('validates a PaymentInstrument', () => {
+    expect(
+      PaymentInstrumentSchema.safeParse({ id: 'pi-1', type: 'credit' })
+        .success,
+    ).toBe(true);
+  });
+});

--- a/code/sdk/typescript/tsconfig.json
+++ b/code/sdk/typescript/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src", "scripts", "test"]
+}


### PR DESCRIPTION
# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google-agentic-commerce/AP2?tab=contributing-ov-file#how-to-contribute).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass
- [x] Appropriate docs were updated (if necessary)

Addresses #67 🦕

## What this adds

`code/sdk/typescript`, a publishable `@ap2-protocol/sdk` npm package: Zod schemas + TypeScript types for AP2's mandate and receipt models, generated directly from the canonical JSON Schemas in `code/sdk/schemas/ap2` (the same source of truth `code/sdk/schemas/generate.py` generates the Python SDK from).

```ts
import { PaymentMandateSchema } from '@ap2-protocol/sdk';

const result = PaymentMandateSchema.safeParse({
  transaction_id: 'tx_1',
  payee: { id: 's-1', name: 'Shop' },
  payment_amount: { amount: 1000, currency: 'USD' },
  payment_instrument: { id: 'pi-1', type: 'credit' },
});
```

Exports `PaymentMandate`, `CheckoutMandate`, `OpenPaymentMandate`, `OpenCheckoutMandate`, `PaymentReceipt`, `CheckoutReceipt`, plus the shared types (`Amount`, `Merchant`, `Pisp`, `PaymentInstrument`, `Jwk`, `Item`, `ReceiptStatus`) — each as both a Zod validator and its inferred TS type.

`npm run generate` (`scripts/generate.ts`) dereferences every schema under `code/sdk/schemas/ap2` and emits the matching Zod code, so this can't drift from the protocol the way hand-maintained TS types would (the exact risk the issue calls out under "alternatives considered").

## A correctness bug found and fixed along the way

`payment_receipt.json` / `checkout_receipt.json` each put a `oneOf` alongside `properties`/`required` at the schema root (Success branch requires `psp_confirmation_id`/`network_confirmation_id`; Error branch requires `error`/`error_description`). The underlying [`json-schema-to-zod`](https://github.com/StefanTerdell/json-schema-to-zod) generator only reads each branch's discriminator `const` and silently drops each branch's own `required` list in this "oneOf as sibling constraint" shape — so a `status: "Success"` receipt with no confirmation IDs generated as **valid**. `materializeSiblingOneOf` in `scripts/generate.ts` merges outer + branch `properties`/`required` before generation (the same shape the generator already handles correctly when branches are fully self-contained, e.g. `OpenPaymentMandate.constraints`). Covered by a regression test in `test/schemas.test.ts`.

## Scope

This covers the TS types + validation half of #67 ("mirrors the AP2 IntentMandate, CartMandate, PaymentMandate ... models with validation, e.g. zod"). It intentionally does **not** port `ap2.sdk`'s SD-JWT signing/verification, mandate chain builders, or JWT/JWK helpers — that's cryptography-sensitive code better reviewed on its own. Also unrelated to #144: that PR is a sample application (Genkit + A2A agents) with its own inline, non-reusable schema types, not a publishable library — this package is the standalone SDK #67 is asking for, and the sample could depend on it in a follow-up.

## Known limitations (documented in the package README)

- **`contains` isn't enforced.** Two schemas use `contains` to require "at least one array element matching a specific alternative" (e.g. `OpenCheckoutMandate.constraints` should include a `checkout.line_items` entry). `json-schema-to-zod` doesn't support `contains`; it's silently dropped rather than hand-patched into generated output. Flagged in the README rather than papered over — happy to follow up with a `.refine()`-emitting fix if that's the preferred direction.
- **No compile-time narrowing on the `oneOf`-branch schemas** (`PaymentReceipt`, `CheckoutReceipt`, `OpenPaymentMandate.constraints` entries) — generated as `z.object(...).and(z.any().superRefine(...))`, and TS collapses `T & any` to `any`. Runtime validation is correct and tested; only static narrowing is coarser than the flat schemas.

## Testing

```sh
cd code/sdk/typescript
npm install
npm run generate   # regenerates src/generated/ from code/sdk/schemas/ap2
npm run lint        # eslint, mirrors code/web-client's config
npm run typecheck   # tsc --noEmit
npm run test         # vitest — 20 tests, incl. the oneOf regression test
npm run build        # tsup esm+cjs+dts
```

All pass locally. `dist/` is gitignored (not committed), matching a standard npm package layout; `package-lock.json` is committed, matching `code/web-client`.

## CLA

I'll sign the Google CLA via the bot's prompt on this PR.
