### PR TITLE
fix(sdjwt): honor expected aud/nonce on every KB hop

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -185,3 +185,5 @@ XVCJ
 Yapily
 Zalopay
 Zalora
+sdjwt
+SDJWT

--- a/code/sdk/python/ap2/sdk/sdjwt/kb_sd_jwt.py
+++ b/code/sdk/python/ap2/sdk/sdjwt/kb_sd_jwt.py
@@ -125,13 +125,16 @@ def verify(
     # them into inline dicts so the cnf check below works correctly.
     _resolve_delegate_payload(payload, token)
     common.verify_binding(payload, prev_token)
-    if typ in TYP_TERMINAL:
-        common.verify_expected_claims(
-            payload,
-            expected_aud=expected_aud,
-            expected_nonce=expected_nonce,
-            token_label='KB-SD-JWT',
-        )
+    # aud/nonce checks apply to every hop when the caller binds them, not just
+    # the terminal one: an intermediate hop presented to the wrong recipient
+    # must fail too. (Mandatory presence of expected_aud/expected_nonce on
+    # terminal hops that carry those claims is a separate follow-up.)
+    common.verify_expected_claims(
+        payload,
+        expected_aud=expected_aud,
+        expected_nonce=expected_nonce,
+        token_label='KB-SD-JWT',
+    )
     has_cnf = _delegate_payload_has_cnf(payload)
     if typ in TYP_TERMINAL and has_cnf:
         raise ValueError("Terminal KB-SD-JWT MUST NOT carry a 'cnf' claim")


### PR DESCRIPTION
## Summary

`verify()` only called `verify_expected_claims` under `if typ in TYP_TERMINAL`, so on an intermediate hop (`typ kb+sd-jwt+kb`) a caller that passes `expected_aud` or `expected_nonce` got no check at all. That is why `test_verify_rejects_aud_mismatch` and `test_verify_rejects_nonce_mismatch` in `kb_sd_jwt_intermediate_tests.py` fail on main.

Move the check out of the terminal guard so it runs on every hop. Matches the `verify()` docstring (expected match is a general check) and `create()` (which already requires `aud` and `nonce` on every hop).

## Scope note (split)

Per discussion with @chopmob-cloud (and the contract / deployment / CI sequencing from @giorgioroth / AlgoVoi / @arjun2075), this PR is **only** the supplied-expectation fix. The stronger behaviour change — a terminal hop that carries `aud`/`nonce` must be bound even when the caller passed no expectation — lands as a follow-up with its own compatibility note and tests, so this change can green the two intermediate-hop tests and unblock #325 without settling a protocol question by default.

## Test plan

- Intermediate-hop mismatch tests now pass: `test_verify_rejects_aud_mismatch`, `test_verify_rejects_nonce_mismatch`
- Existing terminal-hop tests that already pass `expected_aud`/`expected_nonce` unchanged
- No new fail-closed-on-unbound behaviour in this PR

## CI

`cla/google` is green. Lint Code Base is the repo-wide Biome scan from #306 and also fails on main; unrelated to this Python-only diff.