### PR TITLE
fix(constraints): match merchant/payee by stable non-empty id (#315)

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -127,6 +127,11 @@ Payoneer
 paypal
 Payplug
 pids
+PISP
+Pisp
+Pisps
+pisp
+pisps
 pmezard
 proguard
 Proguard

--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -118,6 +118,7 @@ okhttp
 opentelemetry
 otelgrpc
 otelhttp
+otherpisp
 Otherville
 OURCYGPATTERN
 Palo
@@ -154,6 +155,7 @@ ropeproject
 RPCURL
 Rulebook
 screenreaders
+SECP
 setlocal
 sharedpref
 Shopcider
@@ -163,6 +165,7 @@ Signifyd
 skus
 solana
 Splitit
+spoofable
 Spyder
 spyderproject
 spyproject

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  statuses: write
+  pull-requests: write
+
 jobs:
   build:
     name: Lint Code Base
@@ -11,12 +16,13 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v8
+        uses: super-linter/super-linter/slim@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -25,6 +31,7 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           FILTER_REGEX_EXCLUDE: "^(\\.github/|\\.vscode/|code/samples/).*|CODE_OF_CONDUCT.md|CHANGELOG.md"
           VALIDATE_BIOME_FORMAT: false
+          VALIDATE_BIOME_LINT: false
           VALIDATE_PYTHON_BLACK: false
           VALIDATE_PYTHON_FLAKE8: false
           VALIDATE_PYTHON_ISORT: false

--- a/code/sdk/python/ap2/sdk/constraints.py
+++ b/code/sdk/python/ap2/sdk/constraints.py
@@ -43,27 +43,18 @@ class MandateContext(BaseModel):
 
 
 def merchant_matches(candidate: Merchant, target: Merchant) -> bool:
-    """Match merchants by ``id`` (preferred) or by ``name`` + ``website``."""
+    """Match merchants by a stable, non-empty ``id``.
+
+    Merchant/payee identity must be established by ``id``.  The display
+    fields (``name`` and ``website``) are attacker-controllable and are
+    never sufficient to prove that two merchant/payee objects are the same
+    actor, so an empty or missing ``id`` on either side never matches (see
+    issue #315).
+    """
     candidate_id = candidate.id
+    target_id = target.id if isinstance(target, Merchant) else target.get('id')
 
-    if isinstance(target, Merchant):
-        target_id = target.id
-        target_name = target.name
-        target_website = target.website
-    else:
-        target_id = target.get('id')
-        target_name = target.get('name')
-        target_website = target.get('website')
-
-    if candidate_id and target_id:
-        return candidate_id == target_id
-
-    return (
-        candidate.name == target_name
-        and bool(candidate.name)
-        and candidate.website == target_website
-        and bool(candidate.website)
-    )
+    return bool(candidate_id) and candidate_id == target_id
 
 
 class PaymentConstraintEvaluator(ABC):

--- a/code/sdk/python/ap2/tests/constraints_tests.py
+++ b/code/sdk/python/ap2/tests/constraints_tests.py
@@ -96,29 +96,17 @@ def _checkout(merchant=None, line_items=None, **kw):
         pytest.param(
             Merchant(id='m-1', name='A', website='https://a.com'),
             Merchant(id='m-1', name='B', website='https://b.com'),
-            id='by_id',
-        ),
-        pytest.param(
-            Merchant(id='', name='Shop', website='https://shop.com'),
-            Merchant(id='', name='Shop', website='https://shop.com'),
-            id='by_name_and_website',
+            id='by_id_ignores_display_fields',
         ),
         pytest.param(
             Merchant(id='m-1', name='A'),
             Merchant(id='m-1', name='B').model_dump(mode='json'),
             id='dict_target_by_id',
         ),
-        pytest.param(
-            Merchant(id='', name='Shop', website='https://shop.com'),
-            Merchant(id='', name='Shop', website='https://shop.com').model_dump(
-                mode='json'
-            ),
-            id='dict_target_by_name_and_website',
-        ),
     ],
 )
 def test_merchant_matches(candidate, target):
-    """Merchants that should match do match."""
+    """Merchants with equal, non-empty ids match regardless of display."""
     assert merchant_matches(candidate, target)
 
 
@@ -131,14 +119,35 @@ def test_merchant_matches(candidate, target):
             id='different_id',
         ),
         pytest.param(
-            Merchant(id='', name='Shop'),
-            Merchant(id='', name='Shop'),
-            id='name_only_without_website',
-        ),
-        pytest.param(
             Merchant(id='m-1', name='A'),
             Merchant(id='m-2', name='A').model_dump(mode='json'),
             id='dict_target_different_id',
+        ),
+        # Regression for issue #315: display fields (name + website) are
+        # spoofable and must never establish identity when an id is empty.
+        pytest.param(
+            Merchant(id='', name='Shop', website='https://shop.com'),
+            Merchant(id='', name='Shop', website='https://shop.com'),
+            id='spoofed_name_website_empty_id',
+        ),
+        pytest.param(
+            Merchant(id='', name='Shop', website='https://shop.com'),
+            Merchant(id='', name='Shop', website='https://shop.com').model_dump(
+                mode='json'
+            ),
+            id='spoofed_name_website_empty_id_dict',
+        ),
+        # An authorized merchant with a real id must not be matched by an
+        # attacker who supplies an empty id but copies name + website.
+        pytest.param(
+            Merchant(id='m-1', name='Shop', website='https://shop.com'),
+            Merchant(id='', name='Shop', website='https://shop.com'),
+            id='real_id_vs_empty_id_same_display',
+        ),
+        pytest.param(
+            Merchant(id='', name='Shop'),
+            Merchant(id='', name='Shop'),
+            id='name_only_without_website',
         ),
         pytest.param(
             Merchant(id='', name='Shop', website=''),


### PR DESCRIPTION
## Summary

Fixes #315. `merchant_matches()` in `constraints.py` compared `id` only when both sides were truthy and otherwise fell back to matching on `name` + `website`. Because `Merchant.id` permits an empty string (the schema requires the field but sets no `minLength`), a payee could be matched on spoofable display fields instead of a stable identifier. This helper backs `AllowedPayeeEvaluator`, `AllowedMerchantsEvaluator` and `check_preset_payment_claims`, so the gap let a merchant with an empty `id` and a copied `name`/`website` match an authorised entry (CWE-639).

## Fix

Require a non-empty `id` and match by exact `id` equality; drop the `name` + `website` fallback entirely. There is no safe empty-id case: in the closed mandate the display fields are attacker-controlled, and the schema already requires `id`, so no well-formed mandate depended on the fallback.

## Tests

Two existing positive tests asserted the vulnerable behaviour (match by `name`+`website`); these are updated to no-match, and three cases are added: a spoofed `name`/`website` with an empty `id` (object and dict forms) and a real-id-vs-empty-id-same-display case. All must no-match; a legitimate `id` match still matches.

## Validation

- `constraints_tests.py`: 48 passed with the fix.
- Reverting only `constraints.py` (keeping the new tests) fails exactly the three spoof-defence cases; restoring passes.
- Full Python SDK suite: no new failures (two pre-existing SD-JWT failures are unrelated and fail identically on `main`).

## Note

The previous docstring documented the `name`+`website` fallback as intended, and the shipped tests codified it, so this PR necessarily rewrites those two positive tests. That is deliberate: the fallback only ever fired on degenerate or malicious empty-id input, which the schema's required `id` otherwise precludes. A defence-in-depth follow-up worth considering separately is adding `"minLength": 1` to `id` in `merchant.json`.
