### PR TITLE
ci: run Python SDK and sample regression tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,39 @@
+name: Python tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  python-tests:
+    name: SDK and sample regression tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: "0.11.12"
+          python-version: "3.12"
+
+      - name: Sync workspace
+        run: uv sync --all-packages
+
+      - name: Run SDK tests
+        run: uv run --no-sync python -m pytest code/sdk/python/ap2/tests/ -v
+
+      - name: Run sample regression tests
+        run: uv run --no-sync python -m pytest code/samples/python/tests/ -v


### PR DESCRIPTION
# Description

The Python SDK tests (`code/sdk/python/ap2/tests/`) and the sample regression tests
(`code/samples/python/tests/`) are not currently executed by any GitHub Actions
workflow, so regressions in either suite are only caught when a contributor runs
pytest locally.

This PR adds a single Python 3.12 CI job that syncs the AP2 uv workspace once and
then runs both suites.

## What this changes

- adds `.github/workflows/python-tests.yml` — one job, on pushes to `main` and pull
  requests targeting `main`
- syncs once with `uv sync --all-packages`, then runs both suites with
  `uv run --no-sync` so they reuse that environment instead of re-resolving per step

## What this deliberately does not change

- no SDK, sample, or protocol behavior
- no dependency-locking policy change. AP2 currently has no committed `uv.lock`
  (removed in #246), so the workflow resolves the workspace at run time, matching the
  repository's current setup. This PR does not reintroduce a lockfile.
- no `paths:` filter initially, so the check behaves predictably on every PR rather
  than depending on workflow-level path skipping. Straightforward to narrow if
  maintainers prefer lower CI usage.
- no Python version matrix. The project supports 3.11+; 3.12 keeps this first version
  small, and a minimum-supported-version matrix is a reasonable follow-up.

## Workflow hardening

Third-party actions are pinned to immutable commit SHAs, `persist-credentials: false`
is set on checkout, workflow permissions are `contents: read`, and the job is bounded
with `timeout-minutes: 15`. These are defensive choices rather than an existing
repository-wide requirement.

## Current status — draft

This is opened as a draft because the checks are expected to be red on the current
`main` baseline:

- `code/samples/python/tests/` does not exist on `main` yet — it is added by #310, so
  the sample step currently collects no tests.
- Two pre-existing SDK failures on `main`
  (`kb_sd_jwt_intermediate_tests.py::test_verify_rejects_aud_mismatch` and
  `::test_verify_rejects_nonce_mismatch`) are addressed by #313.

Local run on Python 3.12 against this branch: SDK suite 186 passed / 2 failed (the two
above), sample suite 0 collected. This PR intentionally does not modify `kb_sd_jwt`,
the failing tests, or #310 — it only adds the workflow. Once #310 and #313 land, this
branch will be rebased so the check can be evaluated against a green baseline.

The sample-test coverage motivation came out of the discussion on #310, which notes
that no CI job currently runs the sample pytest suite. This PR does not fix #310.

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google-agentic-commerce/AP2?tab=contributing-ov-file#how-to-contribute).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [ ] Ensure the tests and linter pass — see "Current status" above; two pre-existing SDK failures (#313) and the missing sample test directory (#310) are expected on the current baseline.
- [x] Appropriate docs were updated (if necessary) — N/A, CI-only change.
