### PR TITLE
fix(sdk): preserve type-specific PaymentInstrument extension fields through signing

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -22,6 +22,7 @@ CMSPI
 cmwallet
 cncf
 Cobo
+codegen
 Connor
 contentnegotiation
 credman
@@ -29,6 +30,7 @@ Crossmint
 cryptographical
 CYGPATTERN
 Dafiti
+datamodel
 disclosable
 Disclosable
 davecgh
@@ -149,6 +151,8 @@ ropeproject
 RPCURL
 Rulebook
 screenreaders
+sdjwt
+SECP
 setlocal
 sharedpref
 Shopcider

--- a/code/sdk/python/ap2/sdk/generated/types/payment_instrument.py
+++ b/code/sdk/python/ap2/sdk/generated/types/payment_instrument.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class PaymentInstrument(BaseModel):
@@ -12,6 +12,9 @@ class PaymentInstrument(BaseModel):
     Instrument used for payment.
     """
 
+    model_config = ConfigDict(
+        extra='allow',
+    )
     id: str = Field(..., description='unique identifier for this instrument')
     type: str = Field(
         ..., description='unique string identifying this category of instrument'

--- a/code/sdk/python/ap2/tests/payment_instrument_extension_tests.py
+++ b/code/sdk/python/ap2/tests/payment_instrument_extension_tests.py
@@ -1,0 +1,143 @@
+"""Round-trip tests for type-specific PaymentInstrument extension fields.
+
+The AP2 specification states that additional properties MAY be defined for a
+specific Payment Instrument ``type`` (specification.md, Payment Instrument).
+The x402 instrument type carries ``payee_address`` and ``facilitator``. These
+fields must survive the full sign -> parse -> verify round trip, because the
+signed Payment Mandate is the sole authorization the x402 Credential Provider
+acts on. If they are dropped before signing, the Credential Provider reads a
+missing ``payee_address`` and falls back to a default payout address and a
+hard-coded amount -- a fail-open on a payment path (issue #299 item 1).
+"""
+
+from __future__ import annotations
+
+from ap2.sdk.generated.open_payment_mandate import OpenPaymentMandate
+from ap2.sdk.generated.payment_mandate import PaymentMandate
+from ap2.sdk.generated.types.amount import Amount
+from ap2.sdk.generated.types.merchant import Merchant
+from ap2.sdk.generated.types.payment_instrument import PaymentInstrument
+from ap2.sdk.mandate import SdJwtMandate
+from ap2.sdk.payment_mandate_chain import PaymentMandateChain
+from ap2.sdk.sdjwt import sd_jwt
+from ap2.sdk.sdjwt.common import delegate_claims_from_model
+from ap2.tests.conftest import make_cnf
+from cryptography.hazmat.primitives.asymmetric import ec
+
+
+_X402_PAYEE = '0xAbCd000000000000000000000000000000000001'
+_X402_FACILITATOR = 'https://facilitator.example'
+_SIGNED_AMOUNT = 199
+
+# Sentinels standing in for the x402 Credential Provider fallbacks
+# (server.py L148-160): a mismatch means the CP authorized fabricated values.
+_DEFAULT_ADDR = '0x000000000000000000000000000000000000dead'
+_FALLBACK_AMOUNT = 1250
+
+
+def _x402_instrument() -> PaymentInstrument:
+    return PaymentInstrument(
+        id='x402-instrument-1',
+        type='x402',
+        payee_address=_X402_PAYEE,
+        facilitator=_X402_FACILITATOR,
+    )
+
+
+def _closed_payment_mandate() -> PaymentMandate:
+    return PaymentMandate(
+        transaction_id='tx_x402',
+        payee=Merchant(name='Shop', id='s-1'),
+        payment_amount=Amount(amount=_SIGNED_AMOUNT, currency='USD'),
+        payment_instrument=_x402_instrument(),
+    )
+
+
+def _extract_like_x402_cp(chain: PaymentMandateChain):
+    """Verbatim mirror of x402_credentials_provider_mcp/server.py L148-160.
+
+    Any deviation from the signed values here is the fail-open being exercised.
+    """
+    try:
+        payee_address = chain.closed_mandate.payment_instrument.payee_address
+        amount_cents = chain.closed_mandate.payment_amount.amount
+        if not payee_address:
+            payee_address = _DEFAULT_ADDR
+    except AttributeError:
+        payee_address = _DEFAULT_ADDR
+        amount_cents = _FALLBACK_AMOUNT
+    return payee_address, amount_cents
+
+
+# ── Root cause: the pre-sign serialization drops the extension fields ──────
+
+
+def test_model_dump_preserves_type_specific_extension_fields():
+    """``model_dump`` (the pre-sign step) must keep x402 extension fields."""
+    dumped = _x402_instrument().model_dump()
+    assert dumped.get('payee_address') == _X402_PAYEE
+    assert dumped.get('facilitator') == _X402_FACILITATOR
+
+
+def test_delegate_claims_preserve_type_specific_extension_fields():
+    """The delegate claims that actually get signed must carry the fields."""
+    claims = delegate_claims_from_model(_x402_instrument())
+    assert claims.get('payee_address') == _X402_PAYEE
+    assert claims.get('facilitator') == _X402_FACILITATOR
+
+
+# ── Full sign -> parse -> verify round trip ────────────────────────────────
+
+
+def test_x402_extensions_survive_sign_verify_roundtrip(
+    issuer_key, issuer_public_key
+):
+    """x402 extension fields survive create -> verify -> typed parse."""
+    issuer = sd_jwt.create(
+        payload=_closed_payment_mandate(), issuer_key=issuer_key
+    )
+    parsed = SdJwtMandate.from_sd_jwt(
+        issuer.sd_jwt_issuance, issuer_public_key, PaymentMandate
+    )
+    instrument = parsed.mandate_payload.payment_instrument
+    assert instrument.payee_address == _X402_PAYEE
+    assert instrument.facilitator == _X402_FACILITATOR
+
+
+# ── Kill-test: the x402 Credential Provider fail-open ──────────────────────
+
+
+def test_x402_cp_sources_verified_destination_and_amount_not_fallback(
+    issuer_key, issuer_public_key
+):
+    """After the round trip, the CP must read verified values, never fallbacks.
+
+    Kill-test for the payment-path fail-open (issue #299 item 1): mirrors the
+    Credential Provider's extraction. Without preserved extension fields the
+    ``payee_address`` access raises ``AttributeError`` and the CP authorizes a
+    default destination plus the hard-coded ``1250`` amount.
+    """
+    dummy = ec.generate_private_key(ec.SECP256R1())
+    open_mandate = OpenPaymentMandate(
+        constraints=[], cnf=make_cnf(dummy.public_key())
+    )
+    issuer = sd_jwt.create(
+        payload=_closed_payment_mandate(), issuer_key=issuer_key
+    )
+    parsed = SdJwtMandate.from_sd_jwt(
+        issuer.sd_jwt_issuance, issuer_public_key, PaymentMandate
+    )
+    chain = PaymentMandateChain(
+        open_mandate=open_mandate, closed_mandate=parsed.mandate_payload
+    )
+
+    payee_address, amount_cents = _extract_like_x402_cp(chain)
+
+    assert payee_address == _X402_PAYEE, (
+        'x402 CP fell back to the default payout address instead of the '
+        'verified, signed destination'
+    )
+    assert amount_cents == _SIGNED_AMOUNT
+    assert amount_cents != _FALLBACK_AMOUNT, (
+        'x402 CP authorized the hard-coded 1250 fallback amount'
+    )

--- a/code/sdk/schemas/ap2/types/payment_instrument.json
+++ b/code/sdk/schemas/ap2/types/payment_instrument.json
@@ -21,5 +21,6 @@
   "required": [
     "id",
     "type"
-  ]
+  ],
+  "additionalProperties": true
 }


### PR DESCRIPTION
# fix(sdk): preserve type-specific PaymentInstrument extension fields through signing

Addresses #299 item 1: the Python SDK drops `PaymentInstrument` extension
properties before a mandate is signed. Items 2 (allowed-instrument matching,
#301/#324) and the sample amount fallback (#300) are handled separately and are
not touched here.

## Observed vs expected

The specification permits a Payment Instrument `type` to define additional
properties, but the generated `PaymentInstrument` model keeps only `id`, `type`,
and `description` and silently discards the rest. Because signed claims are built
with `model_dump()`, the discarded properties never reach the signed Payment
Mandate, so a verifier that reads them sees a missing value.

Expected: properties a `type` defines (for x402, `payee_address` and
`facilitator`) survive `parse -> model_dump -> sign -> verify`, so the verifier
acts on the values that were actually signed.

## Runtime reproduction (main @ `e1ea56d`)

```python
from ap2.sdk.generated.types.payment_instrument import PaymentInstrument

PaymentInstrument(
    id="x402-usdc-1", type="x402",
    payee_address="0xAbCd...0001", facilitator="https://facilitator.example",
).model_dump()
# -> {'id': 'x402-usdc-1', 'type': 'x402', 'description': None}
# payee_address and facilitator are gone before signing.
```

Driving the actual x402 Credential Provider sample end to end with a genuinely
signed mandate chain (verified destination `0xAbCd...0001`, verified amount
`199c`): the CP reads the now-missing `payee_address`, hits `AttributeError`, and
authorizes an EIP-3009 transfer to `0x7099...79C8` (`DEFAULT_MERCHANT_ADDRESS`)
for `12500000` USDC units (the hard-coded `1250c` fallback), instead of the
verified destination and amount. A valid signed mandate is replaced with
fabricated fallback values on a payment path.

## Exact sites

- Model drops the fields: `code/sdk/python/ap2/sdk/generated/types/payment_instrument.py#L10-L22`
- Signed via `model_dump`: `code/sdk/python/ap2/sdk/sdjwt/common.py#L225-L229`
- CP fail-open on the missing field: `code/samples/python/src/roles/x402_credentials_provider_mcp/server.py#L148-L170`

## Root cause

`payment_instrument.json` declares no `additionalProperties`, and `generate.py`
runs datamodel-codegen, which then emits a model with Pydantic's default posture
(unknown properties ignored). `--field-extra-keys` only whitelists the two
selective-disclosure markers, so nothing else is preserved.

## Fix

Declare the open extension surface in the schema, and let codegen carry it
through:

- `code/sdk/schemas/ap2/types/payment_instrument.json`: add
  `"additionalProperties": true`.
- Regenerated `payment_instrument.py` now carries
  `model_config = ConfigDict(extra='allow')`.

datamodel-codegen already maps a schema's `additionalProperties` onto a Pydantic
`extra` policy in this repo: `jwk.json` (`additionalProperties: false`) generates
`extra='forbid'`, and `ucp/types/buyer.json` / `ucp/types/checkout.json`
(`additionalProperties: true`) already generate `extra='allow'`. This change just
applies the same, existing convention to `PaymentInstrument`. Pydantic v2 then
preserves the extra properties through `model_dump` (hence through signing,
parsing, and verification) and exposes them for attribute access, so the x402 CP
reads the verified `payee_address` and `payment_amount` instead of falling back.

Why schema-driven rather than a per-type model or a global codegen flag:

- The invariant lives in the schema (data), not in hand-written per-`type` code,
  so new instrument types need no SDK changes.
- It **opens** the extension surface rather than closing it, so it does not
  constrain what a `type` may define (`additionalProperties: false` would).
- It is scoped to the one type the spec calls extensible; `jwk`'s intentional
  `extra='forbid'` and every other model are untouched.
- It is the AP2 analogue of the extension-preservation fixes in UCP
  `python-sdk#66` and `js-sdk#40`.

## Spec grounding

- AP2 `specification.md`, Payment Instrument: "additional properties MAY be
  defined for that specific `type`."
- UCP preserves extension (`extra`) data through its model round trip; this keeps
  AP2 consistent with that behavior.

## Class sweep

The class: a generated model that drops a property which is passed in practice
and must travel through signing. Swept every schema and every construction in the
SDK and samples.

| Model | Schema `additionalProperties` | Non-schema fields passed? | Disposition |
|-------|------------------------------|---------------------------|-------------|
| `PaymentInstrument` | absent -> now `true` | yes: `payee_address`, `facilitator` (x402) | **converted** |
| `types/buyer`, `types/checkout` | already `true` | n/a | already `extra='allow'`; no change needed |
| `types/jwk` | `false` (intentionally closed) | no | out of scope; must stay closed |
| `PaymentReceipt`, `CheckoutReceipt` | `oneOf` variants | fields are all schema-declared and preserved | out of scope; no drop |
| all other generated models | absent (default ignore) | no construction passes non-schema fields | out of scope; no observed extension use |

Only `PaymentInstrument` is a genuine instance.

## Side benefit (no behavior anyone relies on changes)

Preserving extension fields also *strengthens* the existing "Pre-set
payment_instrument mismatch" equality check (`constraints.py`): with extras
retained, `PaymentInstrument(id, type)` no longer compares equal to
`PaymentInstrument(id, type, payee_address="0xATTACKER")`, so a `payee_address`
swap that an id/type-only comparison silently accepted is now caught. Extensions
are only ever carried inside the SD-JWT-signed payload and are read by name where
used; instrument matching keys on declared fields only, so no allow-list or
matching decision is loosened by this change.

## Tests

Adds `code/sdk/python/ap2/tests/payment_instrument_extension_tests.py`:

- `model_dump` and delegate-claims preserve the x402 extension fields.
- The fields survive the full `sign -> verify -> typed-parse` round trip.
- Kill-test mirroring the CP extraction (`server.py#L148-L160`): the verified
  destination and amount are sourced, never the default address or the `1250`
  fallback.

Each test fails on `main` for the right reason (fields dropped) and passes with
the fix; removing the regenerated `model_config` line reddens all four.

## Verification

- Full SDK suite: `190 passed`. The two failing `kb_sd_jwt` aud/nonce tests are
  pre-existing on `main` (the KB-hop area of #313/#326) and unrelated to this
  change.
- Regeneration reproducibility: running `generate.py` against the updated schema
  reproduces the committed model body byte for byte. The only regen churn is the
  pre-existing header-timestamp non-determinism, so the committed file keeps the
  existing timestamp to avoid unrelated diff.
- E2E against the real x402 Credential Provider sample: with the fix, the CP
  authorizes the verified payee and `199c`; without it, `DEFAULT_MERCHANT_ADDRESS`
  and `1250c`.
- Lint: the diff introduces no new Biome-lint findings; the new test is
  ruff-clean under the repo `.ruff.toml`. Spellcheck is addressed below.

## Spellcheck

The spellcheck workflow (`cspell-action`, `incremental_files_only`) re-scans each
changed file in full, so it surfaced domain terms not yet in the dictionary
(`datamodel`/`codegen` in the generated model header; `sdjwt`/`SECP` in the new
test). Added those four to `.cspell/custom-words.txt`. No prose words introduced.
