### PR TITLE
fix: add rail_confirmation_verified to PaymentReceipt (closes #327)

### DIFF
--- a/.cspell/custom-words.txt
+++ b/.cspell/custom-words.txt
@@ -185,3 +185,9 @@ XVCJ
 Yapily
 Zalopay
 Zalora
+codegen
+datamodel
+pisp
+PISP
+pyca
+SECP

--- a/code/sdk/python/ap2/sdk/generated/payment_receipt.py
+++ b/code/sdk/python/ap2/sdk/generated/payment_receipt.py
@@ -50,6 +50,10 @@ class PaymentReceiptSuccess(BaseModel):
         ...,
         description='A unique identifier for the transaction confirmation at the network. Present only if status is Success.',
     )
+    rail_confirmation_verified: bool | None = Field(
+        default=None,
+        description='Meaningful only if status is Success. True only if the issuer independently confirmed psp_confirmation_id and network_confirmation_id against the actual payment rail (PSP/network) before issuing this receipt, rather than merely generating them. Absent or false means these confirmation IDs are self-declared by the issuer and MUST NOT be treated as evidence that payment-rail settlement occurred: presence of a confirmation ID proves the issuer asserted a claim, not that the claim was checked.',
+    )
 
 
 class PaymentReceiptError(BaseModel):
@@ -81,6 +85,10 @@ class PaymentReceiptError(BaseModel):
     network_confirmation_id: str | None = Field(
         default=None,
         description='A unique identifier for the transaction confirmation at the network. Present only if status is Success.',
+    )
+    rail_confirmation_verified: bool | None = Field(
+        default=None,
+        description='Meaningful only if status is Success. True only if the issuer independently confirmed psp_confirmation_id and network_confirmation_id against the actual payment rail (PSP/network) before issuing this receipt, rather than merely generating them. Absent or false means these confirmation IDs are self-declared by the issuer and MUST NOT be treated as evidence that payment-rail settlement occurred: presence of a confirmation ID proves the issuer asserted a claim, not that the claim was checked.',
     )
 
 

--- a/code/sdk/python/ap2/sdk/receipt_wrapper.py
+++ b/code/sdk/python/ap2/sdk/receipt_wrapper.py
@@ -45,6 +45,8 @@ class ReceiptClient:
         self,
         payment_mandate_content: PaymentMandate,
         reference: str,
+        psp_confirmation_id: str | None = None,
+        network_confirmation_id: str | None = None,
     ) -> PaymentReceipt:
         """Creates a PaymentReceipt model instance.
 
@@ -52,6 +54,18 @@ class ReceiptClient:
           payment_mandate_content: The closed payment mandate whose PISP this
             receipt inherits as its issuer (when present).
           reference: The payment mandate reference this receipt binds to.
+          psp_confirmation_id: The PSP's own confirmation identifier for this
+            payment, obtained by actually checking the payment rail (e.g. the
+            PSP's settlement/charge API response). If omitted, a locally
+            generated placeholder is used instead and the receipt's
+            `rail_confirmation_verified` field is left unset -- callers MUST
+            NOT treat the resulting receipt as proof that payment-rail
+            settlement occurred unless they supply a real, rail-checked value
+            here (see https://github.com/google-agentic-commerce/AP2/issues/327).
+          network_confirmation_id: The network's own confirmation identifier
+            for this payment. Same caveat as `psp_confirmation_id`: omitting
+            it means the receipt's confirmation IDs are self-declared, not
+            independently verified.
 
         Returns:
           A PaymentReceipt model instance.
@@ -67,11 +81,16 @@ class ReceiptClient:
             issuer=issuer,
             reference=reference,
         )
+        rail_confirmation_verified = (
+            psp_confirmation_id is not None
+            and network_confirmation_id is not None
+        )
         return PaymentReceipt(
             **base,
             payment_id=payment_id,
-            psp_confirmation_id=payment_id,
-            network_confirmation_id=payment_id,
+            psp_confirmation_id=psp_confirmation_id or payment_id,
+            network_confirmation_id=network_confirmation_id or payment_id,
+            rail_confirmation_verified=rail_confirmation_verified,
         )
 
     def create_checkout_receipt(

--- a/code/sdk/python/ap2/tests/receipt_wrapper_tests.py
+++ b/code/sdk/python/ap2/tests/receipt_wrapper_tests.py
@@ -59,6 +59,46 @@ def test_create_payment_receipt_no_pisp(issuer_key):
     assert receipt.root.iss == ''
 
 
+def test_create_payment_receipt_defaults_to_unverified(issuer_key):
+    """Without real rail confirmation IDs, the receipt is honestly unverified.
+
+    Regression test for
+    https://github.com/google-agentic-commerce/AP2/issues/327: a Success
+    receipt must not silently imply payment-rail evidence it does not have.
+    """
+    client = ReceiptClient()
+    reference = 'test_reference'
+    payment_mandate_content = _payment_mandate(pisp=None)
+
+    receipt = client.create_payment_receipt(payment_mandate_content, reference)
+
+    assert receipt.root.status == 'Success'
+    # Placeholder confirmation IDs are still populated (unchanged behavior for
+    # existing callers) ...
+    assert receipt.root.psp_confirmation_id == receipt.root.payment_id
+    assert receipt.root.network_confirmation_id == receipt.root.payment_id
+    # ... but the receipt now says so honestly instead of staying silent.
+    assert receipt.root.rail_confirmation_verified is False
+
+
+def test_create_payment_receipt_with_real_rail_confirmation(issuer_key):
+    """Real, caller-supplied confirmation IDs mark the receipt as verified."""
+    client = ReceiptClient()
+    reference = 'test_reference'
+    payment_mandate_content = _payment_mandate(pisp=None)
+
+    receipt = client.create_payment_receipt(
+        payment_mandate_content,
+        reference,
+        psp_confirmation_id='psp-real-123',
+        network_confirmation_id='network-real-456',
+    )
+
+    assert receipt.root.psp_confirmation_id == 'psp-real-123'
+    assert receipt.root.network_confirmation_id == 'network-real-456'
+    assert receipt.root.rail_confirmation_verified is True
+
+
 def test_create_checkout_receipt():
     """Test creation of a CheckoutReceipt."""
     client = ReceiptClient()

--- a/code/sdk/schemas/ap2/payment_receipt.json
+++ b/code/sdk/schemas/ap2/payment_receipt.json
@@ -40,6 +40,10 @@
     "network_confirmation_id": {
       "type": "string",
       "description": "A unique identifier for the transaction confirmation at the network. Present only if status is Success."
+    },
+    "rail_confirmation_verified": {
+      "type": "boolean",
+      "description": "Meaningful only if status is Success. True only if the issuer independently confirmed psp_confirmation_id and network_confirmation_id against the actual payment rail (PSP/network) before issuing this receipt, rather than merely generating them. Absent or false means these confirmation IDs are self-declared by the issuer and MUST NOT be treated as evidence that payment-rail settlement occurred: presence of a confirmation ID proves the issuer asserted a claim, not that the claim was checked."
     }
   },
   "required": [


### PR DESCRIPTION
## What

`PaymentReceipt(status="Success")` currently asserts payment success purely by producing `psp_confirmation_id`/`network_confirmation_id` — the Python SDK's `create_payment_receipt()` self-generates both as a UUID with no payment-rail check, and the MPP sample signs the result without ever calling out to a PSP or network (#327). A downstream party has no way to tell "independently confirmed against the rail" apart from "the issuer declared success and generated two IDs to satisfy the schema."

This adds an optional `rail_confirmation_verified` boolean to the Success receipt schema — additive and backward compatible, absent/false is exactly the behavior every existing caller already gets. `create_payment_receipt()` now accepts optional `psp_confirmation_id`/`network_confirmation_id`: omit them and nothing changes; supply real, rail-checked values and the receipt honestly reports `rail_confirmation_verified=true`.

**Deliberately does not** try to make the SDK itself perform rail verification — that's business/PSP-specific and out of scope for a spec-level receipt helper. It only stops the receipt from silently implying a check that never happened.

This generalizes the same present-vs-checked distinction this repo's own `negotiation-ref.md` invariant 5 already establishes — discussed with @giskard09 on #327, who suggested drafting this as a concrete proposal rather than another comment.

## How it was built

- Schema: `code/sdk/schemas/ap2/payment_receipt.json` — new optional field, no changes to `required`/`oneOf`.
- Regenerated `code/sdk/python/ap2/sdk/generated/payment_receipt.py` via the documented `uv run --with datamodel-code-generator python3 code/sdk/schemas/generate.py`, scoped to just this schema's diff (the run also touched every other generated file's regen timestamp plus one unrelated `jwk.py` behavior difference from a newer `datamodel-code-generator` version — reverted those, out of scope here).
- `receipt_wrapper.py`: two new optional kwargs, both `None`-default.
- 2 new tests (`test_create_payment_receipt_defaults_to_unverified`, `test_create_payment_receipt_with_real_rail_confirmation`).

## Testing

- `receipt_wrapper_tests.py`: 10/10 pass (8 existing + 2 new).
- Full `code/sdk/python/ap2/tests/` suite: 188 passed. The 2 failures in `kb_sd_jwt_intermediate_tests.py` (aud/nonce mismatch) reproduce identically on `main` before this change — pre-existing, unrelated, already tracked separately as #319.
- `ruff check` / `ruff format --diff` clean on all touched files.

Fixes #327