### PR TITLE
Fix SD-JWT decoder to handle delegation chains

### DIFF
--- a/code/web-client/package-lock.json
+++ b/code/web-client/package-lock.json
@@ -21,7 +21,8 @@
         "sass": "^1.98.0",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.18.0",
-        "vite": "^5.4.0"
+        "vite": "^5.4.0",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2064,6 +2065,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2126,6 +2240,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/bail": {
       "version": "2.0.2",
@@ -2202,6 +2326,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2241,6 +2375,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -2298,6 +2449,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2411,6 +2572,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2457,6 +2628,13 @@
       "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -2674,6 +2852,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2682,6 +2870,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -3162,6 +3360,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3170,6 +3375,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -3935,6 +4150,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4241,6 +4473,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4260,6 +4499,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -4319,6 +4572,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4334,6 +4601,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -4636,6 +4933,95 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4650,6 +5036,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/code/web-client/package.json
+++ b/code/web-client/package.json
@@ -6,6 +6,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "test": "vitest run",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },
@@ -23,6 +24,7 @@
     "sass": "^1.98.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.18.0",
-    "vite": "^5.4.0"
+    "vite": "^5.4.0",
+    "vitest": "^2.1.9"
   }
 }

--- a/code/web-client/src/utils/sdJwtDecoder.test.ts
+++ b/code/web-client/src/utils/sdJwtDecoder.test.ts
@@ -1,0 +1,53 @@
+import {describe, expect, it} from 'vitest';
+import {decodeSdJwt, decodeSdJwtSync} from './sdJwtDecoder';
+
+// A genuine 2-hop dSD-JWT delegation chain (draft-gco-oauth-delegate-sd-jwt-00
+// SS6) minted by the AP2 Python reference SDK: an OpenCheckoutMandate root
+// hop delegating to an agent key, then a CheckoutMandate KB-SD-JWT hop
+// presented to "merchant". Hop 0 carries 1 disclosure, hop 1 carries 2.
+const REAL_TWO_HOP_CHAIN =
+  'eyJhbGciOiAiRVMyNTYiLCAidHlwIjogImV4YW1wbGUrc2Qtand0In0.eyJkZWxlZ2F0ZV9wYXlsb2FkIjogW3siLi4uIjogInJ3TFVNZ1hXM3NNTjZ5bjVnM25qb0JIMVMzUFY0ajluRnhCcHFhMDJwNG8ifV0sICJfc2RfYWxnIjogInNoYS0yNTYifQ.Pj4SJi9BelCFns_TuxOTH2b-7psu2DA4SISLmqcikSn1GiqhqAjVYxXK_hhUBwp4ofslSGauCrBiKn_VXSCwBg~WyJKUU5ES2xEZGxKRUgwYlY5RUFweDRBIiwgeyJ2Y3QiOiAibWFuZGF0ZS5jaGVja291dC5vcGVuLjEiLCAiY29uc3RyYWludHMiOiBbXSwgImNuZiI6IHsiandrIjogeyJrdHkiOiAiRUMiLCAiY3J2IjogIlAtMjU2IiwgIngiOiAibWtYNUJNNW1LbmhTMzZjMHVLZWNHNW16M0VvU1VyYnA3bjF5bmdNdWJBTSIsICJ5IjogIlRCRkRfdkRTdWdBZmluMVdIZnlBUHNndmhSQjVKNFQyTWhtVVZ4cFJRN1kiLCAiYWxnIjogIkVTMjU2In19fV0~~eyJhbGciOiAiRVMyNTYiLCAidHlwIjogImtiK3NkLWp3dCJ9.eyJkZWxlZ2F0ZV9wYXlsb2FkIjogW3siLi4uIjogIjU2UmpJZk8weVBGRm9mVHhMZVBUejNJX3pKaFM1bjJQY3ZqWTg1Nk9vbFEifV0sICJpYXQiOiAxNzg4NTY4Nzg4LCAiYXVkIjogIm1lcmNoYW50IiwgIm5vbmNlIjogIm1lcmNoYW50LW5vbmNlIiwgInNkX2hhc2giOiAiVFVTUWlmd2U1OFpxRjJSVWtHLVVwZTh1TjQtSkxUZU5ELXRrbmpBdmtRTSIsICJfc2RfYWxnIjogInNoYS0yNTYifQ.a7LvlGynBP_zAVbA_HZjqWSALfiH_HuVuP9A8_ApgxyKGx1PXTx4_U4-5PWkLC0ZRXFr_tKIQAhoBUXdCIISEg~WyJnbGVTN0l5bG9NREJsbExxZ1lsRUxBIiwgeyJfc2QiOiBbIjVoR0ctNVhOdmVuQTFyaURLczRIazJtTmtWZElabGZJU2dObjByV0d3LU0iXSwgInZjdCI6ICJtYW5kYXRlLmNoZWNrb3V0LjEiLCAiY2hlY2tvdXRfaGFzaCI6ICJoYXNoIn1d~WyJQUlR5em5CZ05PNWE5UnR4T1BEa1lBIiwgImNoZWNrb3V0X2p3dCIsICJoZHIuYm9keS5zaWciXQ~';
+
+// A plain single-hop SD-JWT issuance (no chain), used to prove the fix
+// doesn't change the existing single-token behavior at all.
+const SINGLE_HOP_TOKEN =
+  'eyJhbGciOiAiRVMyNTYiLCAidHlwIjogImV4YW1wbGUrc2Qtand0In0.eyJfc2QiOiBbXX0.VStKGOA5TdLsrjahM4dRfDrbsy7BmrUNGw3jaBuxZnHYvmS2EnQ-ib7zSCUVBGGbcyORDFCMd_F6gr8CM9N3WQ~';
+
+describe('decodeSdJwt / decodeSdJwtSync', () => {
+  for (const decode of [decodeSdJwt, decodeSdJwtSync]) {
+    describe(decode.name, () => {
+      it('decodes a plain single-hop token exactly as before (no `hops`)', async () => {
+        const decoded = await decode(SINGLE_HOP_TOKEN);
+        expect(decoded.hops).toBeUndefined();
+        expect(decoded.issuerJwt.payload._sd).toEqual([]);
+        expect(decoded.disclosures).toEqual([]);
+        expect(decoded.kbJwt).toBeUndefined();
+      });
+
+      it('decodes every hop of a real 2-hop delegation chain, not just the first', async () => {
+        const decoded = await decode(REAL_TWO_HOP_CHAIN);
+
+        expect(decoded.hops).toHaveLength(2);
+        const [hop0, hop1] = decoded.hops!;
+
+        // Hop 0: the root Open Checkout Mandate, 1 disclosure.
+        expect(hop0.issuerJwt.payload.delegate_payload).toBeDefined();
+        expect(hop0.disclosures).toHaveLength(1);
+        expect(hop0.kbJwt).toBeUndefined();
+
+        // Hop 1: the terminal KB-SD-JWT, 2 disclosures. Under the old
+        // single-`~`-split logic these were silently dropped or
+        // misattributed to hop 0.
+        expect(hop1.issuerJwt.header.typ).toBe('kb+sd-jwt');
+        expect(hop1.issuerJwt.payload.aud).toBe('merchant');
+        expect(hop1.disclosures).toHaveLength(2);
+        expect(hop1.kbJwt).toBeUndefined();
+
+        // Top-level fields describe hop 0, for backward compatibility with
+        // existing single-hop callers.
+        expect(decoded.issuerJwt).toEqual(hop0.issuerJwt);
+        expect(decoded.disclosures).toEqual(hop0.disclosures);
+      });
+    });
+  }
+});

--- a/code/web-client/src/utils/sdJwtDecoder.ts
+++ b/code/web-client/src/utils/sdJwtDecoder.ts
@@ -4,6 +4,10 @@
  * Decodes SD-JWT tokens (IETF SD-JWT spec) into their component parts:
  *   <issuer_jwt>~<disclosure_1>~<disclosure_2>~...~<kb_jwt>
  *
+ * Also decodes `~~`-joined dSD-JWT delegation chains
+ * (draft-gco-oauth-delegate-sd-jwt-00 §6), where each hop is itself a full
+ * SD-JWT of the form above: `<hop_0>~~<hop_1>~~...~~<hop_n>`.
+ *
  * Ported from ap2/internal_skills/format_mandate_logs/scripts/format_logs.py.
  * Pure client-side, no network calls.
  */
@@ -30,6 +34,13 @@ export interface DecodedSdJwt {
   issuerJwt: DecodedJwtWithDiagnostics;
   disclosures: DecodedDisclosure[];
   kbJwt?: DecodedJwtWithDiagnostics;
+  /**
+   * Present when the decoded token was a `~~`-joined dSD-JWT delegation
+   * chain: one entry per hop, in order. `issuerJwt`/`disclosures`/`kbJwt`
+   * above always describe hop 0, so existing single-hop callers keep
+   * working unchanged for both single tokens and chains.
+   */
+  hops?: DecodedSdJwt[];
 }
 
 /** Decode base64url (with or without padding) to a UTF-8 string. */
@@ -118,60 +129,46 @@ export function decodeJwt(token: string): DecodedJwtWithDiagnostics {
   };
 }
 
-/**
- * Decode an SD-JWT token into its parts.
- *
- * Format variants:
- *   - Issuance: `<jwt>~<disc1>~<disc2>~` (trailing tilde, no KB-JWT)
- *   - Presentation: `<jwt>~<disc1>~...~<kb_jwt>` (last segment is JWT w/ 3 parts)
- */
-export async function decodeSdJwt(token: string): Promise<DecodedSdJwt> {
-  const segments = token.split('~');
-  if (segments.length < 1) {
-    throw new Error('Malformed SD-JWT: empty token');
-  }
-
-  const issuerJwt = decodeJwt(segments[0]);
-
-  // Remaining segments: optional disclosures + optional KB-JWT
+/** Splits off trailing disclosures / optional KB-JWT common to both decoders. */
+function splitHopSegments(segments: string[]): {rest: string[]; kbJwtSegment?: string} {
   const rest = segments.slice(1);
   // Trailing empty string indicates the trailing `~` at end of issuance form.
   if (rest.length > 0 && rest[rest.length - 1] === '') rest.pop();
 
-  let kbJwt: DecodedJwt | undefined;
   // Last segment is a KB-JWT if it looks like `header.payload.sig` (three parts).
   if (rest.length > 0) {
     const last = rest[rest.length - 1];
     if (last.includes('.') && last.split('.').length === 3) {
-      try {
-        kbJwt = decodeJwt(last);
-        rest.pop();
-      } catch {
-        // Not a JWT after all; leave as a disclosure.
-      }
+      rest.pop();
+      return {rest, kbJwtSegment: last};
     }
   }
+  return {rest};
+}
 
+function decodeDisclosures(
+  raws: string[],
+  digestFor: (raw: string) => string,
+): DecodedDisclosure[] {
   const disclosures: DecodedDisclosure[] = [];
-  for (const raw of rest) {
+  for (const raw of raws) {
     if (!raw) continue;
     try {
       const decoded = JSON.parse(b64urlToString(raw)) as unknown;
-      const digest = await sha256Base64Url(raw);
       if (Array.isArray(decoded)) {
         if (decoded.length === 3) {
           disclosures.push({
             salt: String(decoded[0]),
             key: String(decoded[1]),
             value: decoded[2],
-            digest,
+            digest: digestFor(raw),
             raw,
           });
         } else if (decoded.length === 2) {
           disclosures.push({
             salt: String(decoded[0]),
             value: decoded[1],
-            digest,
+            digest: digestFor(raw),
             raw,
           });
         }
@@ -180,8 +177,60 @@ export async function decodeSdJwt(token: string): Promise<DecodedSdJwt> {
       // Skip malformed disclosure.
     }
   }
+  return disclosures;
+}
+
+/** Decodes a single SD-JWT hop: `<jwt>~<disc1>~...~<optional kb_jwt>`. */
+async function decodeSingleHop(token: string): Promise<DecodedSdJwt> {
+  const segments = token.split('~');
+  if (segments.length < 1) {
+    throw new Error('Malformed SD-JWT: empty token');
+  }
+  const issuerJwt = decodeJwt(segments[0]);
+  const {rest, kbJwtSegment} = splitHopSegments(segments);
+  const kbJwt = kbJwtSegment ? tryDecodeJwt(kbJwtSegment) : undefined;
+
+  const digests = new Map<string, string>();
+  for (const raw of rest) {
+    if (!raw) continue;
+    digests.set(raw, await sha256Base64Url(raw));
+  }
+  const disclosures = decodeDisclosures(rest, (raw) => digests.get(raw) ?? '');
 
   return {issuerJwt, disclosures, kbJwt};
+}
+
+function decodeSingleHopSync(token: string): DecodedSdJwt {
+  const segments = token.split('~');
+  if (segments.length < 1) {
+    throw new Error('Malformed SD-JWT: empty token');
+  }
+  const issuerJwt = decodeJwt(segments[0]);
+  const {rest, kbJwtSegment} = splitHopSegments(segments);
+  const kbJwt = kbJwtSegment ? tryDecodeJwt(kbJwtSegment) : undefined;
+  const disclosures = decodeDisclosures(rest, () => '');
+
+  return {issuerJwt, disclosures, kbJwt};
+}
+
+function tryDecodeJwt(segment: string): DecodedJwtWithDiagnostics | undefined {
+  try {
+    return decodeJwt(segment);
+  } catch {
+    // Not a JWT after all; caller already popped it, so it's simply dropped.
+    return undefined;
+  }
+}
+
+/**
+ * Decode an SD-JWT token, or a `~~`-joined dSD-JWT delegation chain, into
+ * its parts. For a chain, `hops` holds every hop fully decoded and the
+ * top-level `issuerJwt`/`disclosures`/`kbJwt` describe hop 0.
+ */
+export async function decodeSdJwt(token: string): Promise<DecodedSdJwt> {
+  const hopTokens = token.split('~~');
+  const hops = await Promise.all(hopTokens.map(decodeSingleHop));
+  return hops.length > 1 ? {...hops[0], hops} : hops[0];
 }
 
 /**
@@ -191,54 +240,7 @@ export async function decodeSdJwt(token: string): Promise<DecodedSdJwt> {
  * Useful when the caller doesn't need digests and wants to render synchronously.
  */
 export function decodeSdJwtSync(token: string): DecodedSdJwt {
-  const segments = token.split('~');
-  if (segments.length < 1) {
-    throw new Error('Malformed SD-JWT: empty token');
-  }
-  const issuerJwt = decodeJwt(segments[0]);
-  const rest = segments.slice(1);
-  if (rest.length > 0 && rest[rest.length - 1] === '') rest.pop();
-
-  let kbJwt: DecodedJwt | undefined;
-  if (rest.length > 0) {
-    const last = rest[rest.length - 1];
-    if (last.includes('.') && last.split('.').length === 3) {
-      try {
-        kbJwt = decodeJwt(last);
-        rest.pop();
-      } catch {
-        // ignore
-      }
-    }
-  }
-
-  const disclosures: DecodedDisclosure[] = [];
-  for (const raw of rest) {
-    if (!raw) continue;
-    try {
-      const decoded = JSON.parse(b64urlToString(raw)) as unknown;
-      if (Array.isArray(decoded)) {
-        if (decoded.length === 3) {
-          disclosures.push({
-            salt: String(decoded[0]),
-            key: String(decoded[1]),
-            value: decoded[2],
-            digest: '',
-            raw,
-          });
-        } else if (decoded.length === 2) {
-          disclosures.push({
-            salt: String(decoded[0]),
-            value: decoded[1],
-            digest: '',
-            raw,
-          });
-        }
-      }
-    } catch {
-      // skip
-    }
-  }
-
-  return {issuerJwt, disclosures, kbJwt};
+  const hopTokens = token.split('~~');
+  const hops = hopTokens.map(decodeSingleHopSync);
+  return hops.length > 1 ? {...hops[0], hops} : hops[0];
 }


### PR DESCRIPTION
A display bug in the sample UI.

`sdJwtDecoder.ts` splits on a single `~` before checking for the `~~` chain separator used by delegation chains. When a token is a real chain, which is common for Checkout and Payment mandates, this misreads the second hop as a trailing KB JWT and drops that hop's disclosures.

The fix splits on `~~` first and decodes each hop on its own. `DecodedSdJwt` now has an optional `hops` field with one entry per hop. The existing `issuerJwt`, `disclosures`, and `kbJwt` fields still describe hop 0, so `MandateCard.tsx` and any other caller keep working without changes. Confirmed with `tsc --noEmit`.

Added `vitest`, since this package didn't have a test runner, and a test using a real two hop chain from the Python SDK. The test fails on the old code and passes after the fix.